### PR TITLE
IRQ user

### DIFF
--- a/lib/agbabi/source/irq.s
+++ b/lib/agbabi/source/irq.s
@@ -63,30 +63,34 @@ __agbabi_irq_user:
     mov     r2, #0
     str     r2, [r1, #(REG_IME - REG_IE_IF)]
 
-    @ Change to system mode
-    mrs     r3, cpsr
-    bic     r3, r3, #0xdf
-    orr     r3, r3, #0x1f
-    msr     cpsr, r3
+    @ Change to user mode
+    mrs     r2, cpsr
+    bic     r2, r2, #0xdf
+    orr     r2, r2, #0x1f
+    msr     cpsr, r2
 
     @ Load user IRQ proc
     .weak   __agbabi_irq_uproc
-    ldr     r3, =__agbabi_irq_uproc
-    ldr     r3, [r3]
+    ldr     r2, =__agbabi_irq_uproc
+    ldr     r2, [r2]
 
-    push    { r0-r2, r4-r11, lr }
+    push    { r0-r1, r4-r11, lr }
 
     @ Call __agbabi_irq_proc
     mov     lr, pc
-    bx      r3
+    bx      r2
 
-    pop     { r0-r2, r4-r11, lr }
+    pop     { r0-r1, r4-r11, lr }
+
+    @ Disable REG_IME again
+    mov     r2, #0
+    str     r2, [r1, #(REG_IME - REG_IE_IF)]
 
     @ Change to irq mode
-    mrs     r3, cpsr
-    bic     r3, r3, #0xdf
-    orr     r3, r3, #0x92
-    msr     cpsr, r3
+    mrs     r2, cpsr
+    bic     r2, r2, #0xdf
+    orr     r2, r2, #0x92
+    msr     cpsr, r2
 
     @ Restore REG_IE
     ldrh    r2, [r1]

--- a/lib/multiboot/gba-syscalls.c
+++ b/lib/multiboot/gba-syscalls.c
@@ -14,61 +14,12 @@ void _exit( __attribute__((unused)) int status ) {
     __builtin_unreachable();
 }
 
-int _close( int file ) {
-    return -1;
-}
-
-int _execve( char * name, char ** argv, char ** env ) {
-    errno = ENOMEM;
-    return -1;
-}
-
-int _fork( void ) {
-    errno = EAGAIN;
-    return -1;
-}
-
-int _fstat( int __fd, struct stat * __sbuf ) {
-    __sbuf->st_mode = S_IFCHR;
-    return 0;
-}
-
-int _getpid( void ) {
-    return 1;
-}
-
-int _isatty( int file ) {
-    return 1;
-}
-
-int _kill( int pid, int sig ) {
-    errno = EINVAL;
-    return -1;
-}
-
-int _link( char * old, char * next ) {
-    errno = EMLINK;
-    return -1;
-}
-
-int _lseek( int file, int ptr, int dir ) {
-    return 0;
-}
-
-int _open( const char * name, int flags, int mode ) {
-    return -1;
-}
-
-int _read( int file, char * ptr, int len ) {
-    return 0;
-}
-
 char * _sbrk( int incr ) {
     extern char __ewram_end;
     extern char __ewram_top;
     static char * heap_end = &__ewram_end;
 
-    if ( heap_end + incr > &__ewram_top ) {
+    if ( ( uintptr_t ) ( heap_end + incr ) > ( uintptr_t ) &__ewram_top ) {
         errno = ENOMEM;
         return ( char * ) -1;
     }
@@ -78,25 +29,41 @@ char * _sbrk( int incr ) {
     return prev_heap_end;
 }
 
-int _stat( char * file, struct stat * st ) {
-    st->st_mode = S_IFCHR;
+int _getpid( void ) {
     return 0;
 }
 
-int _times( void * buf ) {
+static int _gba_nosys() {
+    errno = ENOSYS;
     return -1;
 }
 
-int _unlink( char * name ) {
-    errno = ENOENT;
-    return -1;
-}
+int _close( int file ) __attribute__((alias("_gba_nosys")));
 
-int _wait( int * status ) {
-    errno = ECHILD;
-    return -1;
-}
+int _execve( char * name, char ** argv, char ** env ) __attribute__((alias("_gba_nosys")));
 
-int _write( int file, char * ptr, int len ) {
-    return 0;
-}
+int _fork( void ) __attribute__((alias("_gba_nosys")));
+
+int _fstat( int __fd, struct stat * __sbuf ) __attribute__((alias("_gba_nosys")));
+
+int _isatty( int file ) __attribute__((alias("_gba_nosys")));
+
+int _kill( int pid, int sig ) __attribute__((alias("_gba_nosys")));
+
+int _link( char * old, char * next ) __attribute__((alias("_gba_nosys")));
+
+int _lseek( int file, int ptr, int dir ) __attribute__((alias("_gba_nosys")));
+
+int _open( const char * name, int flags, int mode ) __attribute__((alias("_gba_nosys")));
+
+int _read( int file, char * ptr, int len ) __attribute__((alias("_gba_nosys")));
+
+int _stat( char * file, struct stat * st ) __attribute__((alias("_gba_nosys")));
+
+int _times( void * buf ) __attribute__((alias("_gba_nosys")));
+
+int _unlink( char * name ) __attribute__((alias("_gba_nosys")));
+
+int _wait( int * status ) __attribute__((alias("_gba_nosys")));
+
+int _write( int file, char * ptr, int len ) __attribute__((alias("_gba_nosys")));

--- a/lib/rom/gba-syscalls.c
+++ b/lib/rom/gba-syscalls.c
@@ -13,55 +13,6 @@ void _exit( __attribute__((unused)) int status ) {
     __builtin_unreachable();
 }
 
-int _close( int file ) {
-    return -1;
-}
-
-int _execve( char * name, char ** argv, char ** env ) {
-    errno = ENOMEM;
-    return -1;
-}
-
-int _fork( void ) {
-    errno = EAGAIN;
-    return -1;
-}
-
-int _fstat( int __fd, struct stat * __sbuf ) {
-    __sbuf->st_mode = S_IFCHR;
-    return 0;
-}
-
-int _getpid( void ) {
-    return 1;
-}
-
-int _isatty( int file ) {
-    return 1;
-}
-
-int _kill( int pid, int sig ) {
-    errno = EINVAL;
-    return -1;
-}
-
-int _link( char * old, char * next ) {
-    errno = EMLINK;
-    return -1;
-}
-
-int _lseek( int file, int ptr, int dir ) {
-    return 0;
-}
-
-int _open( const char * name, int flags, int mode ) {
-    return -1;
-}
-
-int _read( int file, char * ptr, int len ) {
-    return 0;
-}
-
 char * _sbrk( int incr ) {
     extern char __ewram_end;
     extern char __ewram_top;
@@ -77,25 +28,41 @@ char * _sbrk( int incr ) {
     return prev_heap_end;
 }
 
-int _stat( char * file, struct stat * st ) {
-    st->st_mode = S_IFCHR;
+int _getpid( void ) {
     return 0;
 }
 
-int _times( void * buf ) {
+static int _gba_nosys() {
+    errno = ENOSYS;
     return -1;
 }
 
-int _unlink( char * name ) {
-    errno = ENOENT;
-    return -1;
-}
+int _close( int file ) __attribute__((alias("_gba_nosys")));
 
-int _wait( int * status ) {
-    errno = ECHILD;
-    return -1;
-}
+int _execve( char * name, char ** argv, char ** env ) __attribute__((alias("_gba_nosys")));
 
-int _write( int file, char * ptr, int len ) {
-    return 0;
-}
+int _fork( void ) __attribute__((alias("_gba_nosys")));
+
+int _fstat( int __fd, struct stat * __sbuf ) __attribute__((alias("_gba_nosys")));
+
+int _isatty( int file ) __attribute__((alias("_gba_nosys")));
+
+int _kill( int pid, int sig ) __attribute__((alias("_gba_nosys")));
+
+int _link( char * old, char * next ) __attribute__((alias("_gba_nosys")));
+
+int _lseek( int file, int ptr, int dir ) __attribute__((alias("_gba_nosys")));
+
+int _open( const char * name, int flags, int mode ) __attribute__((alias("_gba_nosys")));
+
+int _read( int file, char * ptr, int len ) __attribute__((alias("_gba_nosys")));
+
+int _stat( char * file, struct stat * st ) __attribute__((alias("_gba_nosys")));
+
+int _times( void * buf ) __attribute__((alias("_gba_nosys")));
+
+int _unlink( char * name ) __attribute__((alias("_gba_nosys")));
+
+int _wait( int * status ) __attribute__((alias("_gba_nosys")));
+
+int _write( int file, char * ptr, int len ) __attribute__((alias("_gba_nosys")));


### PR DESCRIPTION
Two new symbols:
```c
void __agbabi_irq_user( void );
void ( * __agbabi_irq_uproc )( int );
```

### __agbabi_irq_user
This handler does the following:
1. Acknowledges raised IRQs in `REG_IF` and `REG_BIOSIF`
2. Disables the raised IRQs from `REG_IE`
3. Disables `REG_IME`
4. Changes to system mode
5. Calls function pointed to at `__agbabi_irq_uproc`
3. Disables again `REG_IME` (uproc might have enabled it)
6. Changes back to IRQ mode
7. Sets previously cleared IRQs to `REG_IE`
8. Reenables `REG_IME`

### __agbabi_irq_uproc
With `__agbabi_irq_user`, `__agbabi_irq_uproc` is executed with the user stack and with the ability to have nested IRQs.
When entering `__agbabi_irq_uproc`, `REG_IME` is disabled, so it must be enabled manually if nested IRQs are desired.
The `int` argument passed to `__agbabi_irq_uproc` is the raised IRQ flags.