### PR TITLE
Changed libtonc example to https://github.com/exelotl/libtonc-template

### DIFF
--- a/cmake-include/ToncCMakeLists.cmake
+++ b/cmake-include/ToncCMakeLists.cmake
@@ -2,10 +2,14 @@ cmake_minimum_required(VERSION 3.1)
 
 project(tonc C ASM)
 
-file(GLOB TONC_SRC "asm/*.s" "src/*.c" "src/*.s")
+file(GLOB TONC_SRC "asm/*.s" "src/*.c" "src/*.s" "src/font/*.s" "src/tte/*.c" "src/tte/*.s" "src/pre1.3/*.c" "src/pre1.3/*.s")
+
+# Remove tt_iohook.c which isn't compatible right now
+get_filename_component(TTE_IOHOOK "${CMAKE_CURRENT_SOURCE_DIR}/src/tte/tte_iohook.c" ABSOLUTE)
+list(REMOVE_ITEM TONC_SRC "${TTE_IOHOOK}")
 
 add_library(tonc STATIC ${TONC_SRC})
 target_include_directories(tonc SYSTEM PUBLIC "include/")
 
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -mthumb -x assembler-with-cpp")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fno-strict-aliasing -mthumb")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb -Wall -fno-strict-aliasing -Wno-char-subscripts")

--- a/lib/agbabi/include/sys/ucontext.h
+++ b/lib/agbabi/include/sys/ucontext.h
@@ -1,34 +1,42 @@
 #ifndef _AGBABI_SYS_UCONTEXT_H_
 #define _AGBABI_SYS_UCONTEXT_H_
 
+#if defined( __cplusplus )
+extern "C" {
+#endif
+
 #include <stddef.h>
 
 typedef struct {
-    void *  ss_sp;
-    size_t  ss_size;
+    void * ss_sp;
+    size_t ss_size;
 } stack_t;
 
 typedef struct {
-    unsigned long int   arm_r0; // makecontext arg0
-    unsigned long int   arm_r1; // makecontext arg1
-    unsigned long int   arm_r2; // makecontext arg2
-    unsigned long int   arm_r3; // makecontext arg3
-    unsigned long int   arm_r4;
-    unsigned long int   arm_r5;
-    unsigned long int   arm_r6;
-    unsigned long int   arm_r7;
-    unsigned long int   arm_r8;
-    unsigned long int   arm_r9;
-    unsigned long int   arm_r10;
-    unsigned long int   arm_r11;
-    unsigned long int   arm_sp;
-    unsigned long int   arm_lr;
+    unsigned long int arm_r0; // makecontext arg0
+    unsigned long int arm_r1; // makecontext arg1
+    unsigned long int arm_r2; // makecontext arg2
+    unsigned long int arm_r3; // makecontext arg3
+    unsigned long int arm_r4;
+    unsigned long int arm_r5;
+    unsigned long int arm_r6;
+    unsigned long int arm_r7;
+    unsigned long int arm_r8;
+    unsigned long int arm_r9;
+    unsigned long int arm_r10;
+    unsigned long int arm_r11;
+    unsigned long int arm_sp;
+    unsigned long int arm_lr;
 } mcontext_t;
 
 typedef struct ucontext_t {
     struct ucontext_t * uc_link;
-    stack_t             uc_stack;
-    mcontext_t          uc_mcontext;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
 } ucontext_t;
+
+#if defined( __cplusplus )
+}
+#endif
 
 #endif // define _AGBABI_SYS_UCONTEXT_H_

--- a/samples/tonclib/main.c
+++ b/samples/tonclib/main.c
@@ -1,5 +1,18 @@
 #include <tonc.h>
 
 int main( int argc, char * argv[] ) {
+    REG_DISPCNT = DCNT_MODE0 | DCNT_BG0;
+
+    tte_init_chr4c_default(0, BG_CBB(0) | BG_SBB(31));
+    tte_set_pos(92, 68);
+    tte_write("Hello World!");
+
+    irq_init(NULL);
+    irq_enable(II_VBLANK);
+
+    while (1) {
+        VBlankIntrWait();
+    }
+
     return 0;
 }


### PR DESCRIPTION
Credit to @exelotl for providing the source.

`tte/tte_iohook.c` is removed from the compile sources for its dependency on `sys/iosupport.h`, this enables the majority of TTE features.

Oh yeah also added C++ guards for `sys/ucontext.h`.