### PR TITLE
cmake: make gba_target_fix compatible with Ninja

### DIFF
--- a/cmake-include/GBATarget.cmake
+++ b/cmake-include/GBATarget.cmake
@@ -55,7 +55,6 @@ function(gba_target_fix target inputOutput title gameCode makerCode version)
         POST_BUILD
         COMMAND "${GBA_TOOLCHAIN_GBAFIX}" "${inputOutput}" "-t${title}" "-c${gameCode}" "-m${makerCode}" "-r${version}"
         COMMENT "GBA header-fix \"${title}\" ${gameCode}:${makerCode} version ${version}"
-        BYPRODUCTS "${inputOutput}"
     )
 endfunction()
 


### PR DESCRIPTION
Without this, running cmake generate step on the `samples/tonclib` produces:
```
CMake Error:
  Running

   '/usr/local/bin/ninja' '-C' '/gba-toolchain/samples/tonclib/build' '-t' 'cleandead'

  failed with:

   ninja: error: build.ninja:90: multiple rules generate tonclib.gba [-w dupbuild=err]





CMake Error:
  Running

   '/usr/local/bin/ninja' '-C' '/gba-toolchain/samples/tonclib/build' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:90: multiple rules generate tonclib.gba [-w dupbuild=err]
```
because of the added `BYPRODUCTS` of the custom command in `gba_target_fix` (the .gba file is already an output).

@felixjones 