### PR TITLE
Re-written linkerscripts and runtimes

### DIFF
--- a/arm-gba-toolchain.cmake
+++ b/arm-gba-toolchain.cmake
@@ -45,6 +45,12 @@ set(GBA_TOOLCHAIN_TOOLS "${GBA_TOOLCHAIN_LIST_DIR}/tools" CACHE INTERNAL "" FORC
 # Host platform
 #====================
 
+# Detect MSYS
+execute_process(COMMAND uname OUTPUT_VARIABLE uname)
+if (uname MATCHES "^MSYS" OR uname MATCHES "^MINGW")
+    set(MSYS ON)
+endif()
+
 if(WIN32)
     set(HOST_PLATFORM_NAME win32 CACHE INTERNAL "")
     set(HOST_LOCAL_DIRECTORY "$ENV{LocalAppData}" CACHE INTERNAL "")
@@ -65,6 +71,12 @@ elseif(UNIX)
         set(HOST_APPLICATIONS_DIRECTORIES /Applications CACHE INTERNAL "")
         set(HOST_TEMP_DIRECTORY "$ENV{TMPDIR}" CACHE INTERNAL "")
         set(HOST_LOCAL_DIRECTORY /usr/local/share CACHE INTERNAL "")
+    elseif(MSYS)
+        set(HOST_PLATFORM_NAME win32 CACHE INTERNAL "")
+
+        set(HOST_APPLICATIONS_DIRECTORIES /bin /usr/bin /usr/share /usr/local /opt CACHE INTERNAL "")
+        set(HOST_TEMP_DIRECTORY /tmp CACHE INTERNAL "")
+        set(HOST_LOCAL_DIRECTORY ~/ CACHE INTERNAL "")
     endif()
 endif()
 

--- a/cmake/NedcmakeCMakeLists.cmake
+++ b/cmake/NedcmakeCMakeLists.cmake
@@ -32,7 +32,13 @@ foreach(source ${nedclibSrc})
     file(WRITE "${source}" "${filedata}")
 endforeach()
 
-if(WIN32)
+# Detect MSYS
+execute_process(COMMAND uname OUTPUT_VARIABLE uname)
+if (uname MATCHES "^MSYS" OR uname MATCHES "^MINGW")
+    set(MSYS ON)
+endif()
+
+if(WIN32 OR MSYS)
     set(libraryType SHARED)
 else()
     set(libraryType STATIC)
@@ -56,7 +62,7 @@ set_target_properties(nedclib nedcmake
     PROPERTIES CXX_STANDARD 11
 )
 
-if(WIN32)
+if(WIN32 OR MSYS)
     install(TARGETS nedclib DESTINATION .)
 endif()
 install(TARGETS nedcmake DESTINATION .)

--- a/lib/ereader/CMakeLists.txt
+++ b/lib/ereader/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(ereader ASM C)
 
-add_library(ereader STATIC crt0.s ../gba-runtime-nosyscalls.c)
+add_library(ereader STATIC crt0.s ../gba-runtime-nosyscalls.c ../gba-runtime-init_array.c ../gba-runtime-fini_array.c)
 set_target_properties(ereader PROPERTIES OUTPUT_NAME runtime)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/lib/ereader/crt0.s
+++ b/lib/ereader/crt0.s
@@ -46,13 +46,11 @@ _start:
     mov     r0, #0xfe
     swi     #0x1
 
-#ifdef __USE_IWRAM_BASE__
-    // CpuSet copy iwram base
-    ldr     r0, =__iwram_base_lma
-    ldr     r1, =__iwram_base_start
-    ldr     r2, =__iwram_base_cpuset_copy
+    // CpuSet fill sbss
+    ldr     r0, =.Lzero_word
+    ldr     r1, =__sbss_start
+    ldr     r2, =__sbss_cpuset_fill
     swi     #0xb
-#endif
 
     // CpuSet copy ewram data
     ldr     r0, =__ewram_data_cpuset
@@ -61,11 +59,6 @@ _start:
 
     // CpuSet copy iwram
     ldr     r0, =__iwram_cpuset
-    ldm     r0, {r0-r2}
-    swi     #0xb
-
-    // CpuSet copy data
-    ldr     r0, =__data_cpuset
     ldm     r0, {r0-r2}
     swi     #0xb
 
@@ -84,7 +77,9 @@ _start:
     // Finalizers
     .extern __libc_fini_array
     ldr     r2, =__libc_fini_array
+    push    {r0}
     bl      .Lbx_r2
+    pop     {r0}
 
     // Fallthrough to _exit
     .thumb_func

--- a/lib/gba-runtime-fini_array.c
+++ b/lib/gba-runtime-fini_array.c
@@ -1,0 +1,20 @@
+/*
+===============================================================================
+
+ Destructor/finalization array caller
+
+ Copyright (C) 2021-2022 gba-toolchain contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+void __libc_fini_array() {
+    extern void (*__fini_array_start[])() __attribute__((weak));
+    extern void (*__fini_array_end[])() __attribute__((weak));
+
+    const int count = __fini_array_end - __fini_array_start;
+    for (int i = 0; i < count; ++i) {
+        __fini_array_start[i]();
+    }
+}

--- a/lib/gba-runtime-init_array.c
+++ b/lib/gba-runtime-init_array.c
@@ -1,0 +1,28 @@
+/*
+===============================================================================
+
+ Constructor/initialization array caller
+
+ Copyright (C) 2021-2022 gba-toolchain contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+void __libc_init_array() {
+    extern void (*__preinit_array_start[])() __attribute__((weak));
+    extern void (*__preinit_array_end[])() __attribute__((weak));
+
+    int count = __preinit_array_end - __preinit_array_start;
+    for (int i = 0; i < count; ++i) {
+        __preinit_array_start[i]();
+    }
+
+    extern void (*__init_array_start[])() __attribute__((weak));
+    extern void (*__init_array_end[])() __attribute__((weak));
+
+    count = __init_array_end - __init_array_start;
+    for (int i = 0; i < count; ++i) {
+        __init_array_start[i]();
+    }
+}

--- a/lib/gba-runtime-nano.specs
+++ b/lib/gba-runtime-nano.specs
@@ -16,4 +16,4 @@
   %{!shared:%{g*:-lg_nano} %{!p:%{!pg:-lc_nano}}%{p:-lc_p}%{pg:-lc_p}}
 
 *startfile:
-  crti%O%s crtbegin%O%s libruntime.a%s
+  libruntime.a%s

--- a/lib/gba-runtime-nosyscalls.c
+++ b/lib/gba-runtime-nosyscalls.c
@@ -15,20 +15,21 @@
 #undef errno
 extern int errno;
 
-char * __env[1] = { 0 };
-char ** environ = __env;
+#define EWRAM_TOP 0x2040000
 
-char * _sbrk( int incr ) {
+char* __env[1] = { 0 };
+char** environ = __env;
+
+char* _sbrk(int incr) {
     extern char __ewram_end;
-    extern char __ewram_top;
     static char * heap_end = &__ewram_end;
 
-    if ( ( uintptr_t ) ( heap_end + incr ) > ( uintptr_t ) &__ewram_top ) {
+    if ((uintptr_t) (heap_end + incr) >= EWRAM_TOP) {
         errno = ENOMEM;
-        return ( char * ) -1;
+        return (char*) -1;
     }
 
-    char * const prev_heap_end = heap_end;
+    char* prev_heap_end = heap_end;
     heap_end += incr;
     return prev_heap_end;
 }
@@ -38,32 +39,32 @@ static int _gba_nosys() {
     return -1;
 }
 
-int _close( int file ) __attribute__((alias("_gba_nosys")));
+int _close(int file) __attribute__((alias("_gba_nosys")));
 
-int _execve( char * name, char ** argv, char ** env ) __attribute__((alias("_gba_nosys")));
+int _execve(char* __restrict__ name, char** __restrict__ argv, char** __restrict__ env) __attribute__((alias("_gba_nosys")));
 
-int _fork( void ) __attribute__((alias("_gba_nosys")));
+int _fork(void) __attribute__((alias("_gba_nosys")));
 
-int _fstat( int __fd, struct stat * __sbuf ) __attribute__((alias("_gba_nosys")));
+int _fstat(int __fd, struct stat* __sbuf) __attribute__((alias("_gba_nosys")));
 
-int _isatty( int file ) __attribute__((alias("_gba_nosys")));
+int _isatty(int file) __attribute__((alias("_gba_nosys")));
 
-int _kill( int pid, int sig ) __attribute__((alias("_gba_nosys")));
+int _kill(int pid, int sig) __attribute__((alias("_gba_nosys")));
 
-int _link( char * old, char * next ) __attribute__((alias("_gba_nosys")));
+int _link(char* __restrict__ old, char* __restrict__ next) __attribute__((alias("_gba_nosys")));
 
-int _lseek( int file, int ptr, int dir ) __attribute__((alias("_gba_nosys")));
+int _lseek(int file, int ptr, int dir) __attribute__((alias("_gba_nosys")));
 
-int _open( const char * name, int flags, int mode ) __attribute__((alias("_gba_nosys")));
+int _open(const char* __restrict__ name, int flags, int mode) __attribute__((alias("_gba_nosys")));
 
-int _read( int file, char * ptr, int len ) __attribute__((alias("_gba_nosys")));
+int _read(int file, char* ptr, int len) __attribute__((alias("_gba_nosys")));
 
-int _stat( char * file, struct stat * st ) __attribute__((alias("_gba_nosys")));
+int _stat(char* __restrict__ file, struct stat* __restrict__ st) __attribute__((alias("_gba_nosys")));
 
-int _times( void * buf ) __attribute__((alias("_gba_nosys")));
+int _times(void* buf) __attribute__((alias("_gba_nosys")));
 
-int _unlink( char * name ) __attribute__((alias("_gba_nosys")));
+int _unlink(char* name) __attribute__((alias("_gba_nosys")));
 
-int _wait( int * status ) __attribute__((alias("_gba_nosys")));
+int _wait(int* status) __attribute__((alias("_gba_nosys")));
 
-int _write( int file, char * ptr, int len ) __attribute__((alias("_gba_nosys")));
+int _write(int file, char* ptr, int len) __attribute__((alias("_gba_nosys")));

--- a/lib/ldscripts/ereader.ld
+++ b/lib/ldscripts/ereader.ld
@@ -31,7 +31,6 @@ SECTIONS {
     /* crt0.s should start with the Multiboot header, so that comes first */
     .crt0 : ALIGN(4) {
         KEEP (*(.crt0))
-        KEEP (gba-runtime-*.*(.text .text.* .data .data.*))
         . = ALIGN(4);
 
         /* CpuSet constants */

--- a/lib/ldscripts/ereader.ld
+++ b/lib/ldscripts/ereader.ld
@@ -13,252 +13,169 @@ OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 ENTRY(_start)
 
-/*
- * Memory regions
- */
 MEMORY {
-    ewram : ORIGIN = 0x02000000, LENGTH = 256K
-    iwram : ORIGIN = 0x03000000, LENGTH = 32K
+    ewram : ORIGIN = 0x2000000, LENGTH = 256K
+    iwram : ORIGIN = 0x3000000, LENGTH = 32K
 }
 
-/*
- * Common symbols
- */
-__iwram_base = ORIGIN(iwram);
-__iwram_top  = ORIGIN(iwram) + LENGTH(iwram);
-__ewram_base = ORIGIN(ewram);
-__ewram_top  = ORIGIN(ewram) + LENGTH(ewram);
-__sp_irq     = __iwram_top - 0x60;
-__sp_usr     = __sp_irq - 0xA0;
+__sp_irq = ORIGIN(iwram) + LENGTH(iwram) - 0x60;
+__sp_usr = __sp_irq - 0xA0;
+__sp_usr_reserve = 0x200; /* Estimated reserved user stack */
+__ewram_lma = 0x8000000; /* If starting as ROM, copy into EWRAM */
 
-/*
- * Sections
- */
 SECTIONS {
-    /*
-     * EWRAM
-     */
-
+    /* Binary starts at ewram */
+    PROVIDE_HIDDEN (__ewram_start = ORIGIN(ewram));
     . = __ewram_start;
 
-    /* Compiler runtime entry point */
+    /* crt0.s should start with the Multiboot header, so that comes first */
     .crt0 : ALIGN(4) {
         KEEP (*(.crt0))
+        KEEP (gba-runtime-*.*(.text .text.* .data .data.*))
         . = ALIGN(4);
 
-        __ewram_data_cpuset = ABSOLUTE(.);
-        LONG(__ewram_data_lma)
-        LONG(__ewram_data_start)
-        LONG(__ewram_data_cpuset_copy)
-        . = ALIGN(4);
+        /* CpuSet constants */
+        PROVIDE_HIDDEN (__ewram_data_cpuset = ABSOLUTE(.));
+        LONG (__ewram_data_lma)
+        LONG (__ewram_data_start)
+        LONG ((SIZEOF(.ewram) / 4) | (1 << 26))
 
-        __iwram_cpuset = ABSOLUTE(.);
-        LONG(__iwram_lma)
-        LONG(__iwram_start)
-        LONG(__iwram_cpuset_copy)
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__iwram_cpuset = ABSOLUTE(.));
+        LONG (__iwram_lma)
+        LONG (__iwram_start)
+        LONG ((SIZEOF(.iwram) / 4) | (1 << 26))
 
-        __data_cpuset = ABSOLUTE(.);
-        LONG(__data_lma)
-        LONG(__data_start)
-        LONG(__data_cpuset_copy)
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__sbss_cpuset_fill = ABSOLUTE((SIZEOF(.sbss) / 4) | (5 << 24)));
     } > ewram
 
-    /* Program code */
     .text : ALIGN(4) {
-        *(EXCLUDE_FILE (*.iwram.* *.iwram[0-9].*) .text*)
-        *(.stub)
-        . = ALIGN(4);
+        *(.text .text.* .gnu.linkonce.t.*)
     } > ewram
 
-    /*
-     * Initialization
-     */
-    /* Pre-initialization array is called before _init */
     .preinit_array : ALIGN(4) {
-        __preinit_array_start = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP (*(.preinit_array))
-        __preinit_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__preinit_array_end = .);
     } > ewram
 
-    .init : ALIGN(4) {
-        KEEP (*(.init))
-        . = ALIGN(4);
-    } > ewram
-
-    /* Initialization array is called after _init */
     .init_array : ALIGN(4) {
-        __init_array_start = ABSOLUTE(.);
-        KEEP (*(SORT(.init_array.*)))
-        KEEP (*(.init_array))
-        __init_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+        PROVIDE_HIDDEN (__init_array_end = .);
     } > ewram
 
-    /* Finalization code */
-    .fini : ALIGN(4) {
-        KEEP (*(.fini))
-        . = ALIGN(4);
-    } > ewram
-
-    /* Initialization array is called after _fini */
     .fini_array : ALIGN(4) {
-        __fini_array_start = ABSOLUTE(.);
-        KEEP (*(SORT(.fini_array.*)))
-        KEEP (*(.fini_array*))
-        __fini_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+        PROVIDE_HIDDEN (__fini_array_end = .);
     } > ewram
 
-    /*
-     * Exception handling
-     */
+    /* ARM exception handling */
+    .ARM.extab : ALIGN(4) {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > ewram
+
+    . = ALIGN(4);
+    .ARM.exidx : ALIGN(4) {
+        PROVIDE_HIDDEN (__exidx_start = .);
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        PROVIDE_HIDDEN (__exidx_end = .);
+    } > ewram
+
+    /* C++ exception handling */
+    .eh_frame_hdr : ALIGN(4) {
+        *(.eh_frame_hdr)
+        *(.eh_frame_entry .eh_frame_entry.*)
+    } > ewram
+
     .eh_frame : ALIGN(4) {
         KEEP (*(.eh_frame))
         *(.eh_frame.*)
-        . = ALIGN(4);
     } > ewram
 
-    /* Index entries for section unwinding */
-    .ARM.extab : ALIGN(4) {
-        *(.ARM.extab*)
-    } > ewram
-
-    . = ALIGN(4);
-    PROVIDE(__exidx_start = .);
-    .ARM.exidx : ALIGN(4) {
-        *(.ARM.exidx* .gnu.linkonce.armexidx.*);
-    } > ewram
-    . = ALIGN(4);
-    PROVIDE(__exidx_end = .);
-
-    /*
-     * Read only data
-     */
+    /* Read only data */
     .rodata : ALIGN(4) {
-        *(.rodata .rodata.*)
-        . = ALIGN(4);
+        *(SORT(.rodata.sorted.*))
+        *(.rodata .rodata.* .gnu.linkonce.r.*)
     } > ewram
 
-    /*
-     * EWRAM data
-     */
+    /* EWRAM data */
 
-    __ewram_data_lma = ALIGN(4);
+    PROVIDE_HIDDEN (__ewram_data_lma = ALIGN(4));
 
     .ewram : AT(__ewram_data_lma) ALIGN(4) {
-        __ewram_data_start = ABSOLUTE(.);
-        *ewram.*(.data*)
+        PROVIDE_HIDDEN (__ewram_data_start = ABSOLUTE(.));
+        *(.ewram .ewram.*)
+        *.ewram.*(.data .data.*)
         . = ALIGN(4);
-        __ewram_data_end = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__ewram_data_end = ABSOLUTE(.));
     } > ewram
 
-    /*
-     * IWRAM
-     */
-    /* IWRAM base load memory address (source) */
-    __iwram_base_lma = ALIGN(4);
+    PROVIDE_HIDDEN (__ewram_data_lma_end = ALIGN(__ewram_data_lma + (. - __ewram_data_start), 4));
 
-    .iwram.base __iwram_base : AT(__iwram_base_lma) ALIGN(4) {
-        __iwram_base_start = ABSOLUTE(.);
-        *(.iwram.base .iwram.base.*)
-        *iwram.base.*(.text* .data*)
+    /* Small block starting symbol */
+
+    .sbss (NOLOAD) : ALIGN(4) {
+        PROVIDE_HIDDEN (__sbss_start = ABSOLUTE(.));
+        *(.sbss .sbss.*)
+        *(COMMON)
         . = ALIGN(4);
-        __iwram_base_end = ABSOLUTE(.);
-    } > iwram
+        PROVIDE_HIDDEN (__sbss_end = ABSOLUTE(.));
+    } > ewram
 
-    /* IWRAM load memory address (source) */
-    __iwram_lma = __iwram_base_lma + ALIGN(SIZEOF(.iwram.base), 4);
+    /* IWRAM */
+
+    PROVIDE_HIDDEN (__iwram_start = ORIGIN(iwram));
+    PROVIDE_HIDDEN (__iwram_lma = ALIGN(__ewram_data_lma_end, 4));
 
     .iwram : AT(__iwram_lma) ALIGN(4) {
-        __iwram_start = ABSOLUTE(.);
+        KEEP (*(SORT(.iwram.sorted.*)))
         *(.iwram .iwram.*)
-        *iwram.*(.text* .data*)
+        *.iwram.*(.text .text.* .data .data.*)
         . = ALIGN(4);
-        __iwram_end = ABSOLUTE(.);
+
+        /* .data */
+        PROVIDE_HIDDEN (__data_start = ABSOLUTE(.));
+        *(.data .data.* .gnu.linkonce.d.*)
+        . = ALIGN(4);
+        PROVIDE_HIDDEN (__data_end = ABSOLUTE(.));
     } > iwram
 
+    /* IWRAM overalys */
+
+    OVERLAY : NOCROSSREFS AT(__iwram_lma + SIZEOF(.iwram)) {
+        .iwram0 { PROVIDE_HIDDEN (__iwram_overlay = ABSOLUTE(.)); *(.iwram0 .iwram0.*) *.iwram0.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram1 { *(.iwram1 .iwram1.*) *.iwram1.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram2 { *(.iwram2 .iwram2.*) *.iwram2.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram3 { *(.iwram3 .iwram3.*) *.iwram3.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram4 { *(.iwram4 .iwram4.*) *.iwram4.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram5 { *(.iwram5 .iwram5.*) *.iwram5.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram6 { *(.iwram6 .iwram6.*) *.iwram6.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram7 { *(.iwram7 .iwram7.*) *.iwram7.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram8 { *(.iwram8 .iwram8.*) *.iwram8.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram9 { *(.iwram9 .iwram9.*) *.iwram9.*(.text .text.* .data .data.*) . = ALIGN(4); }
+    } > iwram
+
+    PROVIDE_HIDDEN (__iwram_lma_end = ALIGN(__iwram_lma + (. - __iwram_start), 4));
+
     /* Block starting symbol */
-    .bss : ALIGN(4) {
-        __bss_start = ABSOLUTE(.);
-        *(.dynbss)
+
+    .bss (NOLOAD) : ALIGN(4) {
+        PROVIDE_HIDDEN (__bss_start = ABSOLUTE(.));
         *(.bss .bss.*)
         *(COMMON)
         . = ALIGN(4);
-        __bss_end = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__bss_end = ABSOLUTE(.));
     } > iwram
 
-    /* data load memory address (source) */
-    __data_lma = __iwram_lma + ALIGN(SIZEOF(.iwram), 4);
+    PROVIDE_HIDDEN (__iwram_end = __bss_end);
 
-    .data : AT(__data_lma) ALIGN(4) {
-        __data_start = ABSOLUTE(.);
-        *(.data .data.*)
-        SORT(CONSTRUCTORS)
-        . = ALIGN(4);
-        __data_end = ABSOLUTE(.);
-    } > iwram
+    .stack : {
+        ASSERT (__iwram_end <= (__sp_usr - __sp_usr_reserve), "IWRAM sections overlap with reserved stack");
+    }
 
-    /*
-     * IWRAM overlays
-     */
-
-    __iwram_overlay_lma = __data_lma + ALIGN(SIZEOF(.data), 4);
-
-    OVERLAY : NOCROSSREFS AT(__iwram_overlay_lma) {
-        .iwram0 { __iwram_overlay = ABSOLUTE(.); *(.iwram0 .iwram0*) *iwram0.*(.text* .data*) . = ALIGN(4); __iwram0_end = ABSOLUTE(.); }
-        .iwram1 { *(.iwram1 .iwram1*) *iwram1.*(.text* .data*) . = ALIGN(4); __iwram1_end = ABSOLUTE(.); }
-        .iwram2 { *(.iwram2 .iwram2*) *iwram2.*(.text* .data*) . = ALIGN(4); __iwram2_end = ABSOLUTE(.); }
-        .iwram3 { *(.iwram3 .iwram3*) *iwram3.*(.text* .data*) . = ALIGN(4); __iwram3_end = ABSOLUTE(.); }
-        .iwram4 { *(.iwram4 .iwram4*) *iwram4.*(.text* .data*) . = ALIGN(4); __iwram4_end = ABSOLUTE(.); }
-        .iwram5 { *(.iwram5 .iwram5*) *iwram5.*(.text* .data*) . = ALIGN(4); __iwram5_end = ABSOLUTE(.); }
-        .iwram6 { *(.iwram6 .iwram6*) *iwram6.*(.text* .data*) . = ALIGN(4); __iwram6_end = ABSOLUTE(.); }
-        .iwram7 { *(.iwram7 .iwram7*) *iwram7.*(.text* .data*) . = ALIGN(4); __iwram7_end = ABSOLUTE(.); }
-        .iwram8 { *(.iwram8 .iwram8*) *iwram8.*(.text* .data*) . = ALIGN(4); __iwram8_end = ABSOLUTE(.); }
-        .iwram9 { *(.iwram9 .iwram9*) *iwram9.*(.text* .data*) . = ALIGN(4); __iwram9_end = ABSOLUTE(.); }
-    } > iwram
-
-    __iwram0_size = __load_stop_iwram0 - __load_start_iwram0;
-    __iwram1_size = __load_stop_iwram1 - __load_start_iwram1;
-    __iwram2_size = __load_stop_iwram2 - __load_start_iwram2;
-    __iwram3_size = __load_stop_iwram3 - __load_start_iwram3;
-    __iwram4_size = __load_stop_iwram4 - __load_start_iwram4;
-    __iwram5_size = __load_stop_iwram5 - __load_start_iwram5;
-    __iwram6_size = __load_stop_iwram6 - __load_start_iwram6;
-    __iwram7_size = __load_stop_iwram7 - __load_start_iwram7;
-    __iwram8_size = __load_stop_iwram8 - __load_start_iwram8;
-    __iwram9_size = __load_stop_iwram9 - __load_start_iwram9;
-
-    __iwram0_cpuset_copy = ((__iwram0_size) / 4) | (1 << 26);
-    __iwram1_cpuset_copy = ((__iwram1_size) / 4) | (1 << 26);
-    __iwram2_cpuset_copy = ((__iwram2_size) / 4) | (1 << 26);
-    __iwram3_cpuset_copy = ((__iwram3_size) / 4) | (1 << 26);
-    __iwram4_cpuset_copy = ((__iwram4_size) / 4) | (1 << 26);
-    __iwram5_cpuset_copy = ((__iwram5_size) / 4) | (1 << 26);
-    __iwram6_cpuset_copy = ((__iwram6_size) / 4) | (1 << 26);
-    __iwram7_cpuset_copy = ((__iwram7_size) / 4) | (1 << 26);
-    __iwram8_cpuset_copy = ((__iwram8_size) / 4) | (1 << 26);
-    __iwram9_cpuset_copy = ((__iwram9_size) / 4) | (1 << 26);
-
-    __iwram_overlay_size =  __iwram0_size + __iwram1_size + __iwram2_size + __iwram3_size + __iwram4_size +
-                            __iwram5_size + __iwram6_size + __iwram7_size + __iwram8_size + __iwram9_size;
-
-    __iwram_overlay_end = __iwram_overlay + __iwram_overlay_size;
-
-    /*
-     * End of EWRAM symbol
-     */
-
-    __ewram_end = __iwram_overlay_lma + __iwram_overlay_size;
-
-    /*
-     * crt0.s CpuSet constants
-     */
-
-    __iwram_base_cpuset_copy = ((__iwram_base_end - __iwram_base_start) / 4) | (1 << 26);
-    __iwram_cpuset_copy = ((__iwram_end - __iwram_start) / 4) | (1 << 26);
-    __data_cpuset_copy = ((__data_end - __data_start) / 4) | (1 << 26);
-    __ewram_data_cpuset_copy = ((__ewram_data_end - __ewram_data_start) / 4) | (1 << 26);
+    PROVIDE_HIDDEN (__ewram_end = ALIGN(__iwram_lma_end, 4));
+    __ewram_lma_end = ALIGN(__ewram_lma + (__ewram_end - __ewram_start), 4);
 }

--- a/lib/ldscripts/multiboot.ld
+++ b/lib/ldscripts/multiboot.ld
@@ -13,256 +13,171 @@ OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 ENTRY(_start)
 
-/*
- * Memory regions
- */
 MEMORY {
-    ewram : ORIGIN = 0x02000000, LENGTH = 256K
-    iwram : ORIGIN = 0x03000000, LENGTH = 32K
+    ewram : ORIGIN = 0x2000000, LENGTH = 256K
+    iwram : ORIGIN = 0x3000000, LENGTH = 32K
 }
 
-/*
- * Common symbols
- */
-__iwram_base = ORIGIN(iwram);
-__iwram_top  = ORIGIN(iwram) + LENGTH(iwram);
-__ewram_base = ORIGIN(ewram);
-__ewram_top  = ORIGIN(ewram) + LENGTH(ewram);
-__sp_irq     = __iwram_top - 0x60;
-__sp_usr     = __sp_irq - 0xA0;
-__ewram_lma  = 0x8000000; /* If starting as ROM, copy into EWRAM */
+__sp_irq = ORIGIN(iwram) + LENGTH(iwram) - 0x60;
+__sp_usr = __sp_irq - 0xA0;
+__sp_usr_reserve = 0x200; /* Estimated reserved user stack */
+__ewram_lma = 0x8000000; /* If starting as ROM, copy into EWRAM */
 
-/*
- * Sections
- */
 SECTIONS {
-    /*
-     * EWRAM
-     */
-
+    /* Binary starts at ewram */
+    PROVIDE_HIDDEN (__ewram_start = ORIGIN(ewram));
     . = __ewram_start;
 
-    /* Compiler runtime entry point */
+    /* crt0.s should start with the Multiboot header, so that comes first */
     .crt0 : ALIGN(4) {
         KEEP (*(.crt0))
+        KEEP (gba-runtime-*.*(.text .text.* .data .data.*))
         . = ALIGN(4);
 
-        __ewram_data_cpuset = ABSOLUTE(.);
-        LONG(__ewram_data_lma)
-        LONG(__ewram_data_start)
-        LONG(__ewram_data_cpuset_copy)
-        . = ALIGN(4);
+        /* CpuSet constants */
+        PROVIDE_HIDDEN (__ewram_data_cpuset = ABSOLUTE(.));
+        LONG (__ewram_data_lma)
+        LONG (__ewram_data_start)
+        LONG ((SIZEOF(.ewram) / 4) | (1 << 26))
 
-        __iwram_cpuset = ABSOLUTE(.);
-        LONG(__iwram_lma)
-        LONG(__iwram_start)
-        LONG(__iwram_cpuset_copy)
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__iwram_cpuset = ABSOLUTE(.));
+        LONG (__iwram_lma)
+        LONG (__iwram_start)
+        LONG ((SIZEOF(.iwram) / 4) | (1 << 26))
 
-        __data_cpuset = ABSOLUTE(.);
-        LONG(__data_lma)
-        LONG(__data_start)
-        LONG(__data_cpuset_copy)
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__bss_cpuset_fill = ABSOLUTE((SIZEOF(.bss) / 4) | (5 << 24)));
+        PROVIDE_HIDDEN (__sbss_cpuset_fill = ABSOLUTE((SIZEOF(.sbss) / 4) | (5 << 24)));
+        PROVIDE_HIDDEN (__ewram_cpuset = ABSOLUTE(((__ewram_lma_end - __ewram_lma) / 4) | (1 << 26)));
     } > ewram
 
-    /* Program code */
     .text : ALIGN(4) {
-        *(EXCLUDE_FILE (*.iwram.* *.iwram[0-9].*) .text*)
-        *(.stub)
-        . = ALIGN(4);
+        *(.text .text.* .gnu.linkonce.t.*)
     } > ewram
 
-    /*
-     * Initialization
-     */
-    /* Pre-initialization array is called before _init */
     .preinit_array : ALIGN(4) {
-        __preinit_array_start = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP (*(.preinit_array))
-        __preinit_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__preinit_array_end = .);
     } > ewram
 
-    .init : ALIGN(4) {
-        KEEP (*(.init))
-        . = ALIGN(4);
-    } > ewram
-
-    /* Initialization array is called after _init */
     .init_array : ALIGN(4) {
-        __init_array_start = ABSOLUTE(.);
-        KEEP (*(SORT(.init_array.*)))
-        KEEP (*(.init_array))
-        __init_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+        PROVIDE_HIDDEN (__init_array_end = .);
     } > ewram
 
-    /* Finalization code */
-    .fini : ALIGN(4) {
-        KEEP (*(.fini))
-        . = ALIGN(4);
-    } > ewram
-
-    /* Initialization array is called after _fini */
     .fini_array : ALIGN(4) {
-        __fini_array_start = ABSOLUTE(.);
-        KEEP (*(SORT(.fini_array.*)))
-        KEEP (*(.fini_array*))
-        __fini_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+        PROVIDE_HIDDEN (__fini_array_end = .);
     } > ewram
 
-    /*
-     * Exception handling
-     */
+    /* ARM exception handling */
+    .ARM.extab : ALIGN(4) {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > ewram
+
+    . = ALIGN(4);
+    .ARM.exidx : ALIGN(4) {
+        PROVIDE_HIDDEN (__exidx_start = .);
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        PROVIDE_HIDDEN (__exidx_end = .);
+    } > ewram
+
+    /* C++ exception handling */
+    .eh_frame_hdr : ALIGN(4) {
+        *(.eh_frame_hdr)
+        *(.eh_frame_entry .eh_frame_entry.*)
+    } > ewram
+
     .eh_frame : ALIGN(4) {
         KEEP (*(.eh_frame))
         *(.eh_frame.*)
-        . = ALIGN(4);
     } > ewram
 
-    /* Index entries for section unwinding */
-    .ARM.extab : ALIGN(4) {
-        *(.ARM.extab*)
-    } > ewram
-
-    . = ALIGN(4);
-    PROVIDE(__exidx_start = .);
-    .ARM.exidx : ALIGN(4) {
-        *(.ARM.exidx* .gnu.linkonce.armexidx.*);
-    } > ewram
-    . = ALIGN(4);
-    PROVIDE(__exidx_end = .);
-
-    /*
-     * Read only data
-     */
+    /* Read only data */
     .rodata : ALIGN(4) {
-        *(.rodata .rodata.*)
-        . = ALIGN(4);
+        *(SORT(.rodata.sorted.*))
+        *(.rodata .rodata.* .gnu.linkonce.r.*)
     } > ewram
 
-    /*
-     * EWRAM data
-     */
+    /* EWRAM data */
 
-    __ewram_data_lma = ALIGN(4);
+    PROVIDE_HIDDEN (__ewram_data_lma = ALIGN(4));
 
     .ewram : AT(__ewram_data_lma) ALIGN(4) {
-        __ewram_data_start = ABSOLUTE(.);
-        *ewram.*(.data*)
+        PROVIDE_HIDDEN (__ewram_data_start = ABSOLUTE(.));
+        *(.ewram .ewram.*)
+        *.ewram.*(.data .data.*)
         . = ALIGN(4);
-        __ewram_data_end = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__ewram_data_end = ABSOLUTE(.));
     } > ewram
 
-    /*
-     * IWRAM
-     */
+    PROVIDE_HIDDEN (__ewram_data_lma_end = ALIGN(__ewram_data_lma + (. - __ewram_data_start), 4));
 
-    /* IWRAM base load memory address (source) */
-    __iwram_base_lma = ALIGN(4);
+    /* Small block starting symbol */
 
-    .iwram.base __iwram_base : AT(__iwram_base_lma) ALIGN(4) {
-        __iwram_base_start = ABSOLUTE(.);
-        *(.iwram.base .iwram.base.*)
-        *iwram.base.*(.text* .data*)
+    .sbss (NOLOAD) : ALIGN(4) {
+        PROVIDE_HIDDEN (__sbss_start = ABSOLUTE(.));
+        *(.sbss .sbss.*)
+        *(COMMON)
         . = ALIGN(4);
-        __iwram_base_end = ABSOLUTE(.);
-    } > iwram
+        PROVIDE_HIDDEN (__sbss_end = ABSOLUTE(.));
+    } > ewram
 
-    /* IWRAM load memory address (source) */
-    __iwram_lma = __iwram_base_lma + ALIGN(SIZEOF(.iwram.base), 4);
+    /* IWRAM */
+
+    PROVIDE_HIDDEN (__iwram_start = ORIGIN(iwram));
+    PROVIDE_HIDDEN (__iwram_lma = ALIGN(__ewram_data_lma_end, 4));
 
     .iwram : AT(__iwram_lma) ALIGN(4) {
-        __iwram_start = ABSOLUTE(.);
+        KEEP (*(SORT(.iwram.sorted.*)))
         *(.iwram .iwram.*)
-        *iwram.*(.text* .data*)
+        *.iwram.*(.text .text.* .data .data.*)
         . = ALIGN(4);
-        __iwram_end = ABSOLUTE(.);
+
+        /* .data */
+        PROVIDE_HIDDEN (__data_start = ABSOLUTE(.));
+        *(.data .data.* .gnu.linkonce.d.*)
+        . = ALIGN(4);
+        PROVIDE_HIDDEN (__data_end = ABSOLUTE(.));
     } > iwram
 
+    /* IWRAM overalys */
+
+    OVERLAY : NOCROSSREFS AT(__iwram_lma + SIZEOF(.iwram)) {
+        .iwram0 { PROVIDE_HIDDEN (__iwram_overlay = ABSOLUTE(.)); *(.iwram0 .iwram0.*) *.iwram0.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram1 { *(.iwram1 .iwram1.*) *.iwram1.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram2 { *(.iwram2 .iwram2.*) *.iwram2.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram3 { *(.iwram3 .iwram3.*) *.iwram3.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram4 { *(.iwram4 .iwram4.*) *.iwram4.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram5 { *(.iwram5 .iwram5.*) *.iwram5.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram6 { *(.iwram6 .iwram6.*) *.iwram6.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram7 { *(.iwram7 .iwram7.*) *.iwram7.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram8 { *(.iwram8 .iwram8.*) *.iwram8.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram9 { *(.iwram9 .iwram9.*) *.iwram9.*(.text .text.* .data .data.*) . = ALIGN(4); }
+    } > iwram
+
+    PROVIDE_HIDDEN (__iwram_lma_end = ALIGN(__iwram_lma + (. - __iwram_start), 4));
+
     /* Block starting symbol */
-    .bss : ALIGN(4) {
-        __bss_start = ABSOLUTE(.);
-        *(.dynbss)
+
+    .bss (NOLOAD) : ALIGN(4) {
+        PROVIDE_HIDDEN (__bss_start = ABSOLUTE(.));
         *(.bss .bss.*)
         *(COMMON)
         . = ALIGN(4);
-        __bss_end = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__bss_end = ABSOLUTE(.));
     } > iwram
 
-    /* data load memory address (source) */
-    __data_lma = __iwram_lma + ALIGN(SIZEOF(.iwram), 4);
+    PROVIDE_HIDDEN (__iwram_end = __bss_end);
 
-    .data : AT(__data_lma) ALIGN(4) {
-        __data_start = ABSOLUTE(.);
-        *(.data .data.*)
-        SORT(CONSTRUCTORS)
-        . = ALIGN(4);
-        __data_end = ABSOLUTE(.);
-    } > iwram
+    .stack : {
+        ASSERT (__iwram_end <= (__sp_usr - __sp_usr_reserve), "IWRAM sections overlap with reserved stack");
+    }
 
-    /*
-     * IWRAM overlays
-     */
-
-    __iwram_overlay_lma = __data_lma + ALIGN(SIZEOF(.data), 4);
-
-    OVERLAY : NOCROSSREFS AT(__iwram_overlay_lma) {
-        .iwram0 { __iwram_overlay = ABSOLUTE(.); *(.iwram0 .iwram0*) *iwram0.*(.text* .data*) . = ALIGN(32); __iwram0_end = ABSOLUTE(.); }
-        .iwram1 { *(.iwram1 .iwram1*) *iwram1.*(.text* .data*) . = ALIGN(32); __iwram1_end = ABSOLUTE(.); }
-        .iwram2 { *(.iwram2 .iwram2*) *iwram2.*(.text* .data*) . = ALIGN(32); __iwram2_end = ABSOLUTE(.); }
-        .iwram3 { *(.iwram3 .iwram3*) *iwram3.*(.text* .data*) . = ALIGN(32); __iwram3_end = ABSOLUTE(.); }
-        .iwram4 { *(.iwram4 .iwram4*) *iwram4.*(.text* .data*) . = ALIGN(32); __iwram4_end = ABSOLUTE(.); }
-        .iwram5 { *(.iwram5 .iwram5*) *iwram5.*(.text* .data*) . = ALIGN(32); __iwram5_end = ABSOLUTE(.); }
-        .iwram6 { *(.iwram6 .iwram6*) *iwram6.*(.text* .data*) . = ALIGN(32); __iwram6_end = ABSOLUTE(.); }
-        .iwram7 { *(.iwram7 .iwram7*) *iwram7.*(.text* .data*) . = ALIGN(32); __iwram7_end = ABSOLUTE(.); }
-        .iwram8 { *(.iwram8 .iwram8*) *iwram8.*(.text* .data*) . = ALIGN(32); __iwram8_end = ABSOLUTE(.); }
-        .iwram9 { *(.iwram9 .iwram9*) *iwram9.*(.text* .data*) . = ALIGN(32); __iwram9_end = ABSOLUTE(.); }
-    } > iwram
-
-    __iwram0_size = __load_stop_iwram0 - __load_start_iwram0;
-    __iwram1_size = __load_stop_iwram1 - __load_start_iwram1;
-    __iwram2_size = __load_stop_iwram2 - __load_start_iwram2;
-    __iwram3_size = __load_stop_iwram3 - __load_start_iwram3;
-    __iwram4_size = __load_stop_iwram4 - __load_start_iwram4;
-    __iwram5_size = __load_stop_iwram5 - __load_start_iwram5;
-    __iwram6_size = __load_stop_iwram6 - __load_start_iwram6;
-    __iwram7_size = __load_stop_iwram7 - __load_start_iwram7;
-    __iwram8_size = __load_stop_iwram8 - __load_start_iwram8;
-    __iwram9_size = __load_stop_iwram9 - __load_start_iwram9;
-
-    __iwram0_cpuset_copy = ((__iwram0_size) / 4) | (1 << 26);
-    __iwram1_cpuset_copy = ((__iwram1_size) / 4) | (1 << 26);
-    __iwram2_cpuset_copy = ((__iwram2_size) / 4) | (1 << 26);
-    __iwram3_cpuset_copy = ((__iwram3_size) / 4) | (1 << 26);
-    __iwram4_cpuset_copy = ((__iwram4_size) / 4) | (1 << 26);
-    __iwram5_cpuset_copy = ((__iwram5_size) / 4) | (1 << 26);
-    __iwram6_cpuset_copy = ((__iwram6_size) / 4) | (1 << 26);
-    __iwram7_cpuset_copy = ((__iwram7_size) / 4) | (1 << 26);
-    __iwram8_cpuset_copy = ((__iwram8_size) / 4) | (1 << 26);
-    __iwram9_cpuset_copy = ((__iwram9_size) / 4) | (1 << 26);
-
-    __iwram_overlay_size =  __iwram0_size + __iwram1_size + __iwram2_size + __iwram3_size + __iwram4_size +
-                            __iwram5_size + __iwram6_size + __iwram7_size + __iwram8_size + __iwram9_size;
-
-    __iwram_overlay_end = __iwram_overlay + __iwram_overlay_size;
-
-    /*
-     * End of EWRAM symbol
-     */
-
-    __ewram_end = __iwram_overlay_lma + __iwram_overlay_size;
-
-    /*
-     * crt0.s CpuSet constants
-     */
-
-    __iwram_base_cpuset_copy = ((__iwram_base_end - __iwram_base_start) / 4) | (1 << 26);
-    __ewram_cpuset_copy = ((__ewram_end - __ewram_start) / 4) | (1 << 26);
-    __iwram_cpuset_copy = ((__iwram_end - __iwram_start) / 4) | (1 << 26);
-    __bss_cpuset_fill = ((__bss_end - __bss_start) / 4) | (5 << 24);
-    __data_cpuset_copy = ((__data_end - __data_start) / 4) | (1 << 26);
-    __ewram_data_cpuset_copy = ((__ewram_data_end - __ewram_data_start) / 4) | (1 << 26);
+    PROVIDE_HIDDEN (__ewram_end = ALIGN(__iwram_lma_end, 4));
+    __ewram_lma_end = ALIGN(__ewram_lma + (__ewram_end - __ewram_start), 4);
 }

--- a/lib/ldscripts/multiboot.ld
+++ b/lib/ldscripts/multiboot.ld
@@ -31,7 +31,6 @@ SECTIONS {
     /* crt0.s should start with the Multiboot header, so that comes first */
     .crt0 : ALIGN(4) {
         KEEP (*(.crt0))
-        KEEP (gba-runtime-*.*(.text .text.* .data .data.*))
         . = ALIGN(4);
 
         /* CpuSet constants */

--- a/lib/ldscripts/rom.ld
+++ b/lib/ldscripts/rom.ld
@@ -31,7 +31,6 @@ SECTIONS {
     /* crt0.s should start with the ROM header, so that comes first */
     .crt0 : ALIGN(4) {
         KEEP (*(.crt0))
-        KEEP (gba-runtime-*.*(.text .text.* .data .data.*))
         . = ALIGN(4);
 
         /* CpuSet constants */

--- a/lib/ldscripts/rom.ld
+++ b/lib/ldscripts/rom.ld
@@ -108,7 +108,7 @@ SECTIONS {
     PROVIDE_HIDDEN (__iwram_lma = ALIGN(4));
 
     .iwram : AT(__iwram_lma) ALIGN(4) {
-        *(SORT(.iwram.sorted.*))
+        KEEP (*(SORT(.iwram.sorted.*)))
         *(.iwram .iwram.*)
         *.iwram.*(.text .text.* .data .data.*)
         . = ALIGN(4);
@@ -157,7 +157,7 @@ SECTIONS {
     PROVIDE_HIDDEN (__ewram_lma = ALIGN(__iwram_lma + (. - __iwram_start), 4));
 
     .ewram : AT(__ewram_lma) ALIGN(4) {
-        *(SORT(.ewram.sorted.*))
+        KEEP (*(SORT(.ewram.sorted.*)))
         *(.ewram .ewram.*)
         *.ewram.*(.data .data.* .text .text.*)
         . = ALIGN(4);

--- a/lib/ldscripts/rom.ld
+++ b/lib/ldscripts/rom.ld
@@ -13,317 +13,182 @@ OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 ENTRY(_start)
 
-/*
- * Memory regions
- */
 MEMORY {
-    ewram : ORIGIN = 0x02000000, LENGTH = 256K
-    iwram : ORIGIN = 0x03000000, LENGTH = 32K
-    rom   : ORIGIN = 0x08000000, LENGTH = 32M
+    ewram : ORIGIN = 0x2000000, LENGTH = 256K
+    iwram : ORIGIN = 0x3000000, LENGTH = 32K
+    rom   : ORIGIN = 0x8000000, LENGTH = 32M
 }
 
-/*
- * Common symbols
- */
-__rom_start  = ORIGIN(rom);
-__iwram_base = ORIGIN(iwram);
-__iwram_top  = ORIGIN(iwram) + LENGTH(iwram);
-__ewram_base = ORIGIN(ewram);
-__ewram_top  = ORIGIN(ewram) + LENGTH(ewram);
-__sp_irq     = __iwram_top - 0x60;
-__sp_usr     = __sp_irq - 0xA0;
+__sp_irq = ORIGIN(iwram) + LENGTH(iwram) - 0x60;
+__sp_usr = __sp_irq - 0xA0;
+__sp_usr_reserve = 0x200; /* Estimated reserved user stack */
 
-/*
- * Sections
- */
 SECTIONS {
-    /*
-     * ROM
-     */
-
+    /* Binary starts at rom */
+    PROVIDE_HIDDEN (__rom_start = ORIGIN(rom));
     . = __rom_start;
 
-    /* Compiler runtime entry point */
+    /* crt0.s should start with the ROM header, so that comes first */
     .crt0 : ALIGN(4) {
         KEEP (*(.crt0))
+        KEEP (gba-runtime-*.*(.text .text.* .data .data.*))
         . = ALIGN(4);
 
-        __ewram_cpuset = ABSOLUTE(.);
+        /* CpuSet constants */
+        PROVIDE_HIDDEN (__ewram_cpuset = ABSOLUTE(.));
         LONG(__ewram_lma)
         LONG(__ewram_start)
-        LONG(__ewram_cpuset_copy)
-        . = ALIGN(4);
+        LONG((SIZEOF(.ewram) / 4) | (1 << 26))
 
-        __iwram_cpuset = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__iwram_cpuset = ABSOLUTE(.));
         LONG(__iwram_lma)
         LONG(__iwram_start)
-        LONG(__iwram_cpuset_copy)
-        . = ALIGN(4);
+        LONG((SIZEOF(.iwram) / 4) | (1 << 26))
 
-        __data_cpuset = ABSOLUTE(.);
-        LONG(__data_lma)
-        LONG(__data_start)
-        LONG(__data_cpuset_copy)
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__bss_cpuset_fill = (SIZEOF(.bss) / 4) | (5 << 24));
+        PROVIDE_HIDDEN (__sbss_cpuset_fill = (SIZEOF(.sbss) / 4) | (5 << 24));
     } > rom
 
-    /* Program code */
     .text : ALIGN(4) {
-        *(EXCLUDE_FILE (*.iwram.* *.ewram.* *.iwram[0-9].* *.ewram[0-9].*) .text*)
-        *(.stub)
-        . = ALIGN(4);
+        *(.text .text.* .gnu.linkonce.t.*)
     } > rom
 
-    /*
-     * Initialization
-     */
-    /* Pre-initialization array is called before _init */
     .preinit_array : ALIGN(4) {
-        __preinit_array_start = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP (*(.preinit_array))
-        __preinit_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__preinit_array_end = .);
     } > rom
 
-    .init : ALIGN(4) {
-        KEEP (*(.init))
-        . = ALIGN(4);
-    } > rom
-
-    /* Initialization array is called after _init */
     .init_array : ALIGN(4) {
-        __init_array_start = ABSOLUTE(.);
-        KEEP (*(SORT(.init_array.*)))
-        KEEP (*(.init_array))
-        __init_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+        PROVIDE_HIDDEN (__init_array_end = .);
     } > rom
 
-    /* Finalization code */
-    .fini : ALIGN(4) {
-        KEEP (*(.fini))
-        . = ALIGN(4);
-    } > rom
-
-    /* Initialization array is called after _fini */
     .fini_array : ALIGN(4) {
-        __fini_array_start = ABSOLUTE(.);
-        KEEP (*(SORT(.fini_array.*)))
-        KEEP (*(.fini_array*))
-        __fini_array_end = ABSOLUTE(.);
-        . = ALIGN(4);
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+        PROVIDE_HIDDEN (__fini_array_end = .);
     } > rom
 
-    /*
-     * Exception handling
-     */
+    /* ARM exception handling */
+    .ARM.extab : ALIGN(4) {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > rom
+
+    . = ALIGN(4);
+    .ARM.exidx : ALIGN(4) {
+        PROVIDE_HIDDEN (__exidx_start = .);
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        PROVIDE_HIDDEN (__exidx_end = .);
+    } > rom
+
+    /* C++ exception handling */
+    .eh_frame_hdr : ALIGN(4) {
+        *(.eh_frame_hdr)
+        *(.eh_frame_entry .eh_frame_entry.*)
+    } > rom
+
     .eh_frame : ALIGN(4) {
         KEEP (*(.eh_frame))
         *(.eh_frame.*)
-        . = ALIGN(4);
     } > rom
 
-    /* Index entries for section unwinding */
-    .ARM.extab : ALIGN(4) {
-        *(.ARM.extab*)
-    } > rom
-
-    . = ALIGN(4);
-    PROVIDE(__exidx_start = .);
-    .ARM.exidx : ALIGN(4) {
-        *(.ARM.exidx* .gnu.linkonce.armexidx.*);
-    } > rom
-    . = ALIGN(4);
-    PROVIDE(__exidx_end = .);
-
-    /*
-     * Read only data
-     */
+    /* Read only data */
     .rodata : ALIGN(4) {
-        *(.rodata .rodata.*)
-        . = ALIGN(4);
+        *(SORT(.rodata.sorted.*))
+        *(.rodata .rodata.* .gnu.linkonce.r.*)
     } > rom
 
-    /*
-     * IWRAM
-     */
+    /* IWRAM */
 
-    /* IWRAM base load memory address (source) */
-    __iwram_base_lma = ALIGN(4);
-
-    .iwram.base __iwram_base : AT(__iwram_base_lma) ALIGN(4) {
-        __iwram_base_start = ABSOLUTE(.);
-        *(.iwram.base .iwram.base.*)
-        *iwram.base.*(.text* .data*)
-        . = ALIGN(4);
-        __iwram_base_end = ABSOLUTE(.);
-    } > iwram
-
-    /* IWRAM load memory address (source) */
-    __iwram_lma = __iwram_base_lma + ALIGN(SIZEOF(.iwram.base), 4);
+    PROVIDE_HIDDEN (__iwram_start = ORIGIN(iwram));
+    PROVIDE_HIDDEN (__iwram_lma = ALIGN(4));
 
     .iwram : AT(__iwram_lma) ALIGN(4) {
-        __iwram_start = ABSOLUTE(.);
+        *(SORT(.iwram.sorted.*))
         *(.iwram .iwram.*)
-        *iwram.*(.text* .data*)
+        *.iwram.*(.text .text.* .data .data.*)
         . = ALIGN(4);
-        __iwram_end = ABSOLUTE(.);
+
+        /* .data */
+        PROVIDE_HIDDEN (__data_start = ABSOLUTE(.));
+        *(.data .data.* .gnu.linkonce.d.*)
+        . = ALIGN(4);
+        PROVIDE_HIDDEN (__data_end = ABSOLUTE(.));
+    } > iwram
+
+    /* IWRAM overalys */
+
+    OVERLAY : NOCROSSREFS AT(__iwram_lma + SIZEOF(.iwram)) {
+        .iwram0 { __iwram_overlay = ABSOLUTE(.); *(.iwram0 .iwram0.*) *.iwram0.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram1 { *(.iwram1 .iwram1.*) *.iwram1.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram2 { *(.iwram2 .iwram2.*) *.iwram2.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram3 { *(.iwram3 .iwram3.*) *.iwram3.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram4 { *(.iwram4 .iwram4.*) *.iwram4.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram5 { *(.iwram5 .iwram5.*) *.iwram5.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram6 { *(.iwram6 .iwram6.*) *.iwram6.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram7 { *(.iwram7 .iwram7.*) *.iwram7.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram8 { *(.iwram8 .iwram8.*) *.iwram8.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram9 { *(.iwram9 .iwram9.*) *.iwram9.*(.text .text.* .data .data.*) . = ALIGN(32); }
     } > iwram
 
     /* Block starting symbol */
-    .bss : ALIGN(4) {
-        __bss_start = ABSOLUTE(.);
-        *(.dynbss)
+
+    .bss (NOLOAD) : ALIGN(4) {
+        PROVIDE_HIDDEN (__bss_start = ABSOLUTE(.));
         *(.bss .bss.*)
         *(COMMON)
         . = ALIGN(4);
-        __bss_end = ABSOLUTE(.);
+        PROVIDE_HIDDEN (__bss_end = ABSOLUTE(.));
     } > iwram
 
-    /* data load memory address (source) */
-    __data_lma = __iwram_lma + ALIGN(SIZEOF(.iwram), 4);
+    PROVIDE_HIDDEN (__iwram_end = __bss_end);
 
-    .data : AT(__data_lma) ALIGN(4) {
-        __data_start = ABSOLUTE(.);
-        *(.data .data.*)
-        SORT(CONSTRUCTORS)
-        . = ALIGN(4);
-        __data_end = ABSOLUTE(.);
-    } > iwram
+    .stack : {
+        ASSERT (__iwram_end <= (__sp_usr - __sp_usr_reserve), "IWRAM sections overlap with reserved stack");
+    }
 
-    /*
-     * IWRAM overlays
-     */
+    /* EWRAM */
 
-    __iwram_overlay_lma = __data_lma + ALIGN(SIZEOF(.data), 4);
+    PROVIDE_HIDDEN (__ewram_start = ORIGIN(ewram));
+    PROVIDE_HIDDEN (__ewram_lma = ALIGN(__iwram_lma + (. - __iwram_start), 4));
 
-    OVERLAY : NOCROSSREFS AT(__iwram_overlay_lma) {
-        .iwram0 { __iwram_overlay = ABSOLUTE(.); *(.iwram0 .iwram0*) *iwram0.*(.text* .data*) . = ALIGN(32); __iwram0_end = ABSOLUTE(.); }
-        .iwram1 { *(.iwram1 .iwram1*) *iwram1.*(.text* .data*) . = ALIGN(32); __iwram1_end = ABSOLUTE(.); }
-        .iwram2 { *(.iwram2 .iwram2*) *iwram2.*(.text* .data*) . = ALIGN(32); __iwram2_end = ABSOLUTE(.); }
-        .iwram3 { *(.iwram3 .iwram3*) *iwram3.*(.text* .data*) . = ALIGN(32); __iwram3_end = ABSOLUTE(.); }
-        .iwram4 { *(.iwram4 .iwram4*) *iwram4.*(.text* .data*) . = ALIGN(32); __iwram4_end = ABSOLUTE(.); }
-        .iwram5 { *(.iwram5 .iwram5*) *iwram5.*(.text* .data*) . = ALIGN(32); __iwram5_end = ABSOLUTE(.); }
-        .iwram6 { *(.iwram6 .iwram6*) *iwram6.*(.text* .data*) . = ALIGN(32); __iwram6_end = ABSOLUTE(.); }
-        .iwram7 { *(.iwram7 .iwram7*) *iwram7.*(.text* .data*) . = ALIGN(32); __iwram7_end = ABSOLUTE(.); }
-        .iwram8 { *(.iwram8 .iwram8*) *iwram8.*(.text* .data*) . = ALIGN(32); __iwram8_end = ABSOLUTE(.); }
-        .iwram9 { *(.iwram9 .iwram9*) *iwram9.*(.text* .data*) . = ALIGN(32); __iwram9_end = ABSOLUTE(.); }
-    } > iwram
-
-    __iwram0_size = __load_stop_iwram0 - __load_start_iwram0;
-    __iwram1_size = __load_stop_iwram1 - __load_start_iwram1;
-    __iwram2_size = __load_stop_iwram2 - __load_start_iwram2;
-    __iwram3_size = __load_stop_iwram3 - __load_start_iwram3;
-    __iwram4_size = __load_stop_iwram4 - __load_start_iwram4;
-    __iwram5_size = __load_stop_iwram5 - __load_start_iwram5;
-    __iwram6_size = __load_stop_iwram6 - __load_start_iwram6;
-    __iwram7_size = __load_stop_iwram7 - __load_start_iwram7;
-    __iwram8_size = __load_stop_iwram8 - __load_start_iwram8;
-    __iwram9_size = __load_stop_iwram9 - __load_start_iwram9;
-
-    __iwram0_cpuset_copy = ((__iwram0_size) / 4) | (1 << 26);
-    __iwram1_cpuset_copy = ((__iwram1_size) / 4) | (1 << 26);
-    __iwram2_cpuset_copy = ((__iwram2_size) / 4) | (1 << 26);
-    __iwram3_cpuset_copy = ((__iwram3_size) / 4) | (1 << 26);
-    __iwram4_cpuset_copy = ((__iwram4_size) / 4) | (1 << 26);
-    __iwram5_cpuset_copy = ((__iwram5_size) / 4) | (1 << 26);
-    __iwram6_cpuset_copy = ((__iwram6_size) / 4) | (1 << 26);
-    __iwram7_cpuset_copy = ((__iwram7_size) / 4) | (1 << 26);
-    __iwram8_cpuset_copy = ((__iwram8_size) / 4) | (1 << 26);
-    __iwram9_cpuset_copy = ((__iwram9_size) / 4) | (1 << 26);
-
-    __iwram_overlay_size =  __iwram0_size + __iwram1_size + __iwram2_size + __iwram3_size + __iwram4_size +
-                            __iwram5_size + __iwram6_size + __iwram7_size + __iwram8_size + __iwram9_size;
-
-    __iwram_overlay_end = __iwram_overlay + __iwram_overlay_size;
-
-    /*
-     * EWRAM
-     */
-
-    /* EWRAM base load memory address (source) */
-    __ewram_base_lma = __iwram_overlay_lma + __iwram_overlay_size;
-
-    .ewram.base __ewram_base : AT(__ewram_base_lma) ALIGN(4) {
-        __ewram_base_start = ABSOLUTE(.);
-        *(.ewram.base .ewram.base.*)
-        *ewram.base.*(.text* .data*)
-        . = ALIGN(4);
-        __ewram_base_end = ABSOLUTE(.);
-    } > ewram
-
-    /* EWRAM load memory address (source) */
-    __ewram_lma = __ewram_base_lma + ALIGN(SIZEOF(.ewram.base), 4);
-
-    /* EWRAM load memory address (source) */
     .ewram : AT(__ewram_lma) ALIGN(4) {
-        __ewram_start = ABSOLUTE(.);
+        *(SORT(.ewram.sorted.*))
         *(.ewram .ewram.*)
-        *ewram.*(.text* .data*)
+        *.ewram.*(.data .data.* .text .text.*)
         . = ALIGN(4);
-        __ewram_end = ABSOLUTE(.);
     } > ewram
 
-    /*
-     * EWRAM overlays
-     */
+    /* ewram overalys */
 
-    __ewram_overlay_lma = __ewram_lma + ALIGN(SIZEOF(.ewram), 4);
-
-    OVERLAY : NOCROSSREFS AT(__ewram_overlay_lma) {
-        .ewram0 { __ewram_overlay = ABSOLUTE(.); *(.ewram0 .ewram0*) *ewram0.*(.text* .data*) . = ALIGN(32); __ewram0_end = ABSOLUTE(.); }
-        .ewram1 { *(.ewram1 .ewram1*) *ewram1.*(.text* .data*) . = ALIGN(32); __ewram1_end = ABSOLUTE(.); }
-        .ewram2 { *(.ewram2 .ewram2*) *ewram2.*(.text* .data*) . = ALIGN(32); __ewram2_end = ABSOLUTE(.); }
-        .ewram3 { *(.ewram3 .ewram3*) *ewram3.*(.text* .data*) . = ALIGN(32); __ewram3_end = ABSOLUTE(.); }
-        .ewram4 { *(.ewram4 .ewram4*) *ewram4.*(.text* .data*) . = ALIGN(32); __ewram4_end = ABSOLUTE(.); }
-        .ewram5 { *(.ewram5 .ewram5*) *ewram5.*(.text* .data*) . = ALIGN(32); __ewram5_end = ABSOLUTE(.); }
-        .ewram6 { *(.ewram6 .ewram6*) *ewram6.*(.text* .data*) . = ALIGN(32); __ewram6_end = ABSOLUTE(.); }
-        .ewram7 { *(.ewram7 .ewram7*) *ewram7.*(.text* .data*) . = ALIGN(32); __ewram7_end = ABSOLUTE(.); }
-        .ewram8 { *(.ewram8 .ewram8*) *ewram8.*(.text* .data*) . = ALIGN(32); __ewram8_end = ABSOLUTE(.); }
-        .ewram9 { *(.ewram9 .ewram9*) *ewram9.*(.text* .data*) . = ALIGN(32); __ewram9_end = ABSOLUTE(.); }
+    OVERLAY : NOCROSSREFS AT(__ewram_lma + SIZEOF(.ewram)) {
+        .ewram0 { __ewram_overlay = ABSOLUTE(.); *(.ewram0 .ewram0.*) *.ewram0.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram1 { *(.ewram1 .ewram1.*) *.ewram1.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram2 { *(.ewram2 .ewram2.*) *.ewram2.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram3 { *(.ewram3 .ewram3.*) *.ewram3.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram4 { *(.ewram4 .ewram4.*) *.ewram4.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram5 { *(.ewram5 .ewram5.*) *.ewram5.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram6 { *(.ewram6 .ewram6.*) *.ewram6.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram7 { *(.ewram7 .ewram7.*) *.ewram7.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram8 { *(.ewram8 .ewram8.*) *.ewram8.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram9 { *(.ewram9 .ewram9.*) *.ewram9.*(.text .text.* .data .data.*) . = ALIGN(32); }
     } > ewram
 
-    __ewram0_size = __load_stop_ewram0 - __load_start_ewram0;
-    __ewram1_size = __load_stop_ewram1 - __load_start_ewram1;
-    __ewram2_size = __load_stop_ewram2 - __load_start_ewram2;
-    __ewram3_size = __load_stop_ewram3 - __load_start_ewram3;
-    __ewram4_size = __load_stop_ewram4 - __load_start_ewram4;
-    __ewram5_size = __load_stop_ewram5 - __load_start_ewram5;
-    __ewram6_size = __load_stop_ewram6 - __load_start_ewram6;
-    __ewram7_size = __load_stop_ewram7 - __load_start_ewram7;
-    __ewram8_size = __load_stop_ewram8 - __load_start_ewram8;
-    __ewram9_size = __load_stop_ewram9 - __load_start_ewram9;
+    /* Small block starting symbol */
 
-    __ewram0_cpuset_copy = ((__ewram0_size) / 4) | (1 << 26);
-    __ewram1_cpuset_copy = ((__ewram1_size) / 4) | (1 << 26);
-    __ewram2_cpuset_copy = ((__ewram2_size) / 4) | (1 << 26);
-    __ewram3_cpuset_copy = ((__ewram3_size) / 4) | (1 << 26);
-    __ewram4_cpuset_copy = ((__ewram4_size) / 4) | (1 << 26);
-    __ewram5_cpuset_copy = ((__ewram5_size) / 4) | (1 << 26);
-    __ewram6_cpuset_copy = ((__ewram6_size) / 4) | (1 << 26);
-    __ewram7_cpuset_copy = ((__ewram7_size) / 4) | (1 << 26);
-    __ewram8_cpuset_copy = ((__ewram8_size) / 4) | (1 << 26);
-    __ewram9_cpuset_copy = ((__ewram9_size) / 4) | (1 << 26);
+    .sbss (NOLOAD) : ALIGN(4) {
+        PROVIDE_HIDDEN (__sbss_start = ABSOLUTE(.));
+        *(.sbss .sbss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        PROVIDE_HIDDEN (__sbss_end = ABSOLUTE(.));
+    } > ewram
 
-    __ewram_overlay_size =  __ewram0_size + __ewram1_size + __ewram2_size + __ewram3_size + __ewram4_size +
-                            __ewram5_size + __ewram6_size + __ewram7_size + __ewram8_size + __ewram9_size;
+    PROVIDE_HIDDEN (__ewram_end = __sbss_end);
 
-    __ewram_overlay_end = __ewram_overlay + __ewram_overlay_size;
-
-    /*
-     * End of ROM symbol
-     */
-
-    __rom_end = __ewram_overlay_lma + __ewram_overlay_size;
-
-    /*
-     * crt0.s CpuSet constants
-     */
-
-    __iwram_base_cpuset_copy = ((__iwram_base_end - __iwram_base_start) / 4) | (1 << 26);
-    __iwram_cpuset_copy = ((__iwram_end - __iwram_start) / 4) | (1 << 26);
-    __bss_cpuset_fill = ((__bss_end - __bss_start) / 4) | (5 << 24);
-    __data_cpuset_copy = ((__data_end - __data_start) / 4) | (1 << 26);
-    __ewram_base_cpuset_copy = ((__ewram_base_end - __ewram_base_start) / 4) | (1 << 26);
-    __ewram_cpuset_copy = ((__ewram_end - __ewram_start) / 4) | (1 << 26);
+    PROVIDE_HIDDEN (__rom_end = ALIGN(ABSOLUTE(.), 4));
 }

--- a/lib/ldscripts/rom.ld
+++ b/lib/ldscripts/rom.ld
@@ -36,17 +36,17 @@ SECTIONS {
 
         /* CpuSet constants */
         PROVIDE_HIDDEN (__ewram_cpuset = ABSOLUTE(.));
-        LONG(__ewram_lma)
-        LONG(__ewram_start)
-        LONG((SIZEOF(.ewram) / 4) | (1 << 26))
+        LONG (__ewram_lma)
+        LONG (__ewram_start)
+        LONG ((SIZEOF(.ewram) / 4) | (1 << 26))
 
         PROVIDE_HIDDEN (__iwram_cpuset = ABSOLUTE(.));
-        LONG(__iwram_lma)
-        LONG(__iwram_start)
-        LONG((SIZEOF(.iwram) / 4) | (1 << 26))
+        LONG (__iwram_lma)
+        LONG (__iwram_start)
+        LONG ((SIZEOF(.iwram) / 4) | (1 << 26))
 
-        PROVIDE_HIDDEN (__bss_cpuset_fill = (SIZEOF(.bss) / 4) | (5 << 24));
-        PROVIDE_HIDDEN (__sbss_cpuset_fill = (SIZEOF(.sbss) / 4) | (5 << 24));
+        PROVIDE_HIDDEN (__bss_cpuset_fill = ABSOLUTE((SIZEOF(.bss) / 4) | (5 << 24)));
+        PROVIDE_HIDDEN (__sbss_cpuset_fill = ABSOLUTE((SIZEOF(.sbss) / 4) | (5 << 24)));
     } > rom
 
     .text : ALIGN(4) {
@@ -123,17 +123,19 @@ SECTIONS {
     /* IWRAM overalys */
 
     OVERLAY : NOCROSSREFS AT(__iwram_lma + SIZEOF(.iwram)) {
-        .iwram0 { __iwram_overlay = ABSOLUTE(.); *(.iwram0 .iwram0.*) *.iwram0.*(.text .text.* .data .data.*) . = ALIGN(4); }
-        .iwram1 { *(.iwram1 .iwram1.*) *.iwram1.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .iwram2 { *(.iwram2 .iwram2.*) *.iwram2.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .iwram3 { *(.iwram3 .iwram3.*) *.iwram3.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .iwram4 { *(.iwram4 .iwram4.*) *.iwram4.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .iwram5 { *(.iwram5 .iwram5.*) *.iwram5.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .iwram6 { *(.iwram6 .iwram6.*) *.iwram6.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .iwram7 { *(.iwram7 .iwram7.*) *.iwram7.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .iwram8 { *(.iwram8 .iwram8.*) *.iwram8.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .iwram9 { *(.iwram9 .iwram9.*) *.iwram9.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .iwram0 { PROVIDE_HIDDEN (__iwram_overlay = ABSOLUTE(.)); *(.iwram0 .iwram0.*) *.iwram0.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram1 { *(.iwram1 .iwram1.*) *.iwram1.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram2 { *(.iwram2 .iwram2.*) *.iwram2.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram3 { *(.iwram3 .iwram3.*) *.iwram3.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram4 { *(.iwram4 .iwram4.*) *.iwram4.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram5 { *(.iwram5 .iwram5.*) *.iwram5.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram6 { *(.iwram6 .iwram6.*) *.iwram6.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram7 { *(.iwram7 .iwram7.*) *.iwram7.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram8 { *(.iwram8 .iwram8.*) *.iwram8.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .iwram9 { *(.iwram9 .iwram9.*) *.iwram9.*(.text .text.* .data .data.*) . = ALIGN(4); }
     } > iwram
+
+    PROVIDE_HIDDEN (__iwram_lma_end = ALIGN(__iwram_lma + (. - __iwram_start), 4));
 
     /* Block starting symbol */
 
@@ -154,7 +156,7 @@ SECTIONS {
     /* EWRAM */
 
     PROVIDE_HIDDEN (__ewram_start = ORIGIN(ewram));
-    PROVIDE_HIDDEN (__ewram_lma = ALIGN(__iwram_lma + (. - __iwram_start), 4));
+    PROVIDE_HIDDEN (__ewram_lma = __iwram_lma_end);
 
     .ewram : AT(__ewram_lma) ALIGN(4) {
         KEEP (*(SORT(.ewram.sorted.*)))
@@ -166,17 +168,19 @@ SECTIONS {
     /* ewram overalys */
 
     OVERLAY : NOCROSSREFS AT(__ewram_lma + SIZEOF(.ewram)) {
-        .ewram0 { __ewram_overlay = ABSOLUTE(.); *(.ewram0 .ewram0.*) *.ewram0.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram1 { *(.ewram1 .ewram1.*) *.ewram1.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram2 { *(.ewram2 .ewram2.*) *.ewram2.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram3 { *(.ewram3 .ewram3.*) *.ewram3.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram4 { *(.ewram4 .ewram4.*) *.ewram4.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram5 { *(.ewram5 .ewram5.*) *.ewram5.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram6 { *(.ewram6 .ewram6.*) *.ewram6.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram7 { *(.ewram7 .ewram7.*) *.ewram7.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram8 { *(.ewram8 .ewram8.*) *.ewram8.*(.text .text.* .data .data.*) . = ALIGN(32); }
-        .ewram9 { *(.ewram9 .ewram9.*) *.ewram9.*(.text .text.* .data .data.*) . = ALIGN(32); }
+        .ewram0 { PROVIDE_HIDDEN (__ewram_overlay = ABSOLUTE(.)); *(.ewram0 .ewram0.*) *.ewram0.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram1 { *(.ewram1 .ewram1.*) *.ewram1.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram2 { *(.ewram2 .ewram2.*) *.ewram2.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram3 { *(.ewram3 .ewram3.*) *.ewram3.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram4 { *(.ewram4 .ewram4.*) *.ewram4.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram5 { *(.ewram5 .ewram5.*) *.ewram5.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram6 { *(.ewram6 .ewram6.*) *.ewram6.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram7 { *(.ewram7 .ewram7.*) *.ewram7.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram8 { *(.ewram8 .ewram8.*) *.ewram8.*(.text .text.* .data .data.*) . = ALIGN(4); }
+        .ewram9 { *(.ewram9 .ewram9.*) *.ewram9.*(.text .text.* .data .data.*) . = ALIGN(4); }
     } > ewram
+
+    PROVIDE_HIDDEN (__ewram_lma_end = ALIGN(__ewram_lma + (. - __ewram_start), 4));
 
     /* Small block starting symbol */
 
@@ -189,6 +193,5 @@ SECTIONS {
     } > ewram
 
     PROVIDE_HIDDEN (__ewram_end = __sbss_end);
-
-    PROVIDE_HIDDEN (__rom_end = ALIGN(ABSOLUTE(.), 4));
+    PROVIDE_HIDDEN (__rom_end = ALIGN(__ewram_lma_end, 4));
 }

--- a/lib/multiboot/CMakeLists.txt
+++ b/lib/multiboot/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(multiboot ASM C)
 
-add_library(multiboot STATIC crt0.s ../gba-runtime-nosyscalls.c)
+add_library(multiboot STATIC crt0.s ../gba-runtime-nosyscalls.c ../gba-runtime-init_array.c ../gba-runtime-fini_array.c)
 set_target_properties(multiboot PROPERTIES OUTPUT_NAME runtime)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")

--- a/lib/multiboot/crt0.s
+++ b/lib/multiboot/crt0.s
@@ -71,12 +71,10 @@ _start:
     ldr     r2, =__bss_cpuset_fill
     swi     #0xb
 
-#ifdef __USE_IWRAM_BASE__
-    // CpuSet copy iwram base
-    ldr     r0, =__iwram_base_cpuset
-    ldm     r0, {r0-r2}
+    // CpuSet fill sbss
+    ldr     r1, =__sbss_start
+    ldr     r2, =__sbss_cpuset_fill
     swi     #0xb
-#endif
 
     // CpuSet copy ewram data
     ldr     r0, =__ewram_data_cpuset
@@ -85,11 +83,6 @@ _start:
 
     // CpuSet copy iwram
     ldr     r0, =__iwram_cpuset
-    ldm     r0, {r0-r2}
-    swi     #0xb
-
-    // CpuSet copy data
-    ldr     r0, =__data_cpuset
     ldm     r0, {r0-r2}
     swi     #0xb
 
@@ -105,15 +98,11 @@ _start:
     ldr     r2, =main
     bl      .Lbx_r2
 
-    // Store result of main
-    push    {r0}
-
     // Finalizers
     .extern __libc_fini_array
     ldr     r2, =__libc_fini_array
+    push    {r0}
     bl      .Lbx_r2
-
-    // Restore result of main
     pop     {r0}
 
     // Fallthrough to _exit
@@ -135,8 +124,8 @@ _exit:
     // CpuSet copy ewram
     ldr     r0, =__ewram_lma
     ldr     r1, =__ewram_start
-    ldr     r2, =__ewram_cpuset_copy
-    swi     #0xb
+    ldr     r2, =__ewram_cpuset
+    swi     #0xb0000
     b       .Lewram_start
 #endif
 

--- a/lib/rom/CMakeLists.txt
+++ b/lib/rom/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(rom ASM C)
 
-add_library(rom STATIC crt0.s ../gba-runtime-nosyscalls.c)
+add_library(rom STATIC crt0.s ../gba-runtime-nosyscalls.c ../gba-runtime-init_array.c ../gba-runtime-fini_array.c)
 set_target_properties(rom PROPERTIES OUTPUT_NAME runtime)
 
 target_compile_options(rom PRIVATE

--- a/lib/rom/crt0.s
+++ b/lib/rom/crt0.s
@@ -71,21 +71,10 @@ _start:
     ldr     r2, =__bss_cpuset_fill
     swi     #0xb
 
-#ifdef __USE_EWRAM_BASE__
-    // CpuSet copy ewram base
-    ldr     r0, =__ewram_base_lma
-    ldr     r1, =__ewram_base_start
-    ldr     r2, =__ewram_base_cpuset_copy
+    // CpuSet fill sbss
+    ldr     r1, =__sbss_start
+    ldr     r2, =__sbss_cpuset_fill
     swi     #0xb
-#endif
-
-#ifdef __USE_IWRAM_BASE__
-    // CpuSet copy iwram base
-    ldr     r0, =__iwram_base_lma
-    ldr     r1, =__iwram_base_start
-    ldr     r2, =__iwram_base_cpuset_copy
-    swi     #0xb
-#endif
 
     // CpuSet copy ewram
     ldr     r0, =__ewram_cpuset
@@ -94,11 +83,6 @@ _start:
 
     // CpuSet copy iwram
     ldr     r0, =__iwram_cpuset
-    ldm     r0, {r0-r2}
-    swi     #0xb
-
-    // CpuSet copy data
-    ldr     r0, =__data_cpuset
     ldm     r0, {r0-r2}
     swi     #0xb
 
@@ -114,15 +98,11 @@ _start:
     ldr     r2, =main
     bl      .Lbx_r2
 
-    // Store result of main
-    push    {r0}
-
     // Finalizers
     .extern __libc_fini_array
     ldr     r2, =__libc_fini_array
+    push    {r0}
     bl      .Lbx_r2
-
-    // Restore result of main
     pop     {r0}
 
     // Fallthrough to _exit
@@ -136,11 +116,6 @@ _exit:
 .Lbx_r2:
     bx      r2
 
-    // Reference symbols from gba-syscalls.c to prevent removal
-    .global _sbrk
-    .global _kill
-
-    // Placed in own section to allow gc-section removal
     .section .crt0._getpid, "ax", %progbits
     .thumb_func
     .global _getpid

--- a/lib/rom/crt0.s
+++ b/lib/rom/crt0.s
@@ -116,6 +116,10 @@ _exit:
 .Lbx_r2:
     bx      r2
 
+    // Reference symbols from gba-syscalls.c to prevent removal
+    .global _sbrk
+    .global _kill
+
     .section .crt0._getpid, "ax", %progbits
     .thumb_func
     .global _getpid

--- a/samples/11 Linker script/gba-rom.ld
+++ b/samples/11 Linker script/gba-rom.ld
@@ -34,13 +34,7 @@ SECTIONS {
     } > rom
 
     .text : ALIGN(4) {
-        *(.text.unlikely .text.*_unlikely .text.unlikely.*)
-        *(.text.exit .text.exit.*)
-        *(.text.startup .text.startup.*)
-        *(.text.hot .text.hot.*)
-        *(SORT(.text.sorted.*))
-        *(.text .stub .text.* .gnu.linkonce.t.*)
-        *(.glue_7t) *(.glue_7)
+        *(.text .text.* .gnu.linkonce.t.*)
     } > rom
 
     .rodata : ALIGN(4) {
@@ -70,21 +64,20 @@ SECTIONS {
 
     .data __iwram_base : AT(__data_lma) ALIGN(4) {
         __data_start = ABSOLUTE(.);
-        *(.data .data.*)
-        SORT(CONSTRUCTORS)
+        *(.data .data.* .gnu.linkonce.d.*)
         . = ALIGN(4);
         __data_end = ABSOLUTE(.);
     } > iwram
 
     .bss : ALIGN(4) {
         __bss_start = ABSOLUTE(.);
-        *(.dynbss)
         *(.bss .bss.* .gnu.linkonce.b.*)
         *(COMMON)
         . = ALIGN(4);
         __bss_end = ABSOLUTE(.);
     } > iwram
 
+    /* Some link-time constants for copying sections into IWRAM via CpuSet */
     __bss_cpuset_fill = ((__bss_end - __bss_start) / 4) | (5 << 24);
     __data_cpuset_copy = ((__data_end - __data_start) / 4) | (1 << 26);
 }

--- a/samples/6 Overlays/main.c
+++ b/samples/6 Overlays/main.c
@@ -24,7 +24,7 @@ EWRAM0 void print_up() {
     tte_write("Up");
 }
 extern u32 __load_start_ewram0[];
-extern u32 __ewram0_cpuset_copy[];
+extern u32 __load_stop_ewram0[];
 
 EWRAM1 void print_down() {
     tte_erase_screen();
@@ -32,7 +32,7 @@ EWRAM1 void print_down() {
     tte_write("Down");
 }
 extern u32 __load_start_ewram1[];
-extern u32 __ewram1_cpuset_copy[];
+extern u32 __load_stop_ewram1[];
 
 EWRAM2 void print_left() {
     tte_erase_screen();
@@ -40,7 +40,7 @@ EWRAM2 void print_left() {
     tte_write("Left");
 }
 extern u32 __load_start_ewram2[];
-extern u32 __ewram2_cpuset_copy[];
+extern u32 __load_stop_ewram2[];
 
 EWRAM3 void print_right() {
     tte_erase_screen();
@@ -48,7 +48,7 @@ EWRAM3 void print_right() {
     tte_write("Right");
 }
 extern u32 __load_start_ewram3[];
-extern u32 __ewram3_cpuset_copy[];
+extern u32 __load_stop_ewram3[];
 
 int main() {
     REG_DISPCNT = DCNT_MODE0 | DCNT_BG0;
@@ -64,19 +64,23 @@ int main() {
         key_poll();
         VBlankIntrWait();
         if (key_hit(KEY_UP)) {
-            CpuFastSet(__load_start_ewram0, __ewram_overlay, (u32) __ewram0_cpuset_copy);
+            const u32 ewram_size = __load_stop_ewram0 - __load_start_ewram0;
+            CpuSet(__load_start_ewram0, __ewram_overlay, ewram_size | CS_CPY32);
             print_up();
         }
         if (key_hit(KEY_DOWN)) {
-            CpuFastSet(__load_start_ewram1, __ewram_overlay, (u32) __ewram1_cpuset_copy);
+            const u32 ewram_size = __load_stop_ewram1 - __load_start_ewram1;
+            CpuSet(__load_start_ewram1, __ewram_overlay, ewram_size | CS_CPY32);
             print_down();
         }
         if (key_hit(KEY_LEFT)) {
-            CpuFastSet(__load_start_ewram2, __ewram_overlay, (u32) __ewram2_cpuset_copy);
+            const u32 ewram_size = __load_stop_ewram2 - __load_start_ewram2;
+            CpuSet(__load_start_ewram2, __ewram_overlay, ewram_size | CS_CPY32);
             print_left();
         }
         if (key_hit(KEY_RIGHT)) {
-            CpuFastSet(__load_start_ewram3, __ewram_overlay, (u32) __ewram3_cpuset_copy);
+            const u32 ewram_size = __load_stop_ewram3 - __load_start_ewram3;
+            CpuSet(__load_start_ewram3, __ewram_overlay, ewram_size | CS_CPY32);
             print_right();
         }
     }


### PR DESCRIPTION
Removed the extra overlay symbol constants.
Removed `iwram.base` and `ewram.base`, instead you should use `.iwram.sorted` and `.ewram.sorted` (which are sorted!).
Names of various symbols are a bit more sensible/consistent.
Explicit implementations of `__libc_init_array` and `__libc_fini_array` that don't worry about the old `.init` and `.fini` sections.