### PR TITLE
Support for devkitARM toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Changes the compiler from ARM GNU GCC to the host's Clang compiler. This require
 
 The GNU Arm Embedded Toolchain is still required for GCC linking, compiling assembly, objcopy, and for the C/C++ standard libraries.
 
+### -DUSE_DEVKITARM=ON
+
+Changes the compiler from GNU Arm Embedded Toolchain to an installation of devkitARM located at the `DEVKITARM` environment variable.
+
+This avoids downloading GNU Arm Embedded Toolchain and uses devkitARM's provided tools when available (can avoid downloading and compiling host tools). 
+
 ### -DDEPENDENCIES_URL=https://some.url.to/a/place/with/file.ini
 
 Overrides the initial URL used to download `dependecies.ini`.

--- a/arm-gba-toolchain.cmake
+++ b/arm-gba-toolchain.cmake
@@ -14,6 +14,7 @@ cmake_minimum_required(VERSION 3.18)
 #====================
 
 option(USE_CLANG "Enable Clang compiler" OFF)
+option(USE_DEVKITARM "Use devkitARM provided compilers and tools" OFF)
 set(GBA_TOOLCHAIN_URL "https://github.com/felixjones/gba-toolchain/archive/refs/heads/3.0.zip" CACHE STRING "URL to download GBA toolchain")
 set(ARM_GNU_TOOLCHAIN "$ENV{ARM_GNU_TOOLCHAIN}" CACHE PATH "Path to ARM GNU toolchain")
 
@@ -286,15 +287,21 @@ include("${GBA_TOOLCHAIN_LIST_DIR}/cmake/Toolchain.cmake")
 # Find compilers
 #====================
 
-file(LOCK "${GBA_TOOLCHAIN_LOCK}" GUARD FILE)
-_find_arm_gnu()
-file(LOCK "${GBA_TOOLCHAIN_LOCK}" RELEASE)
+if(USE_DEVKITARM)
+    _find_devkitarm()
+    set(toolchain $ENV{DEVKITARM})
+else()
+    file(LOCK "${GBA_TOOLCHAIN_LOCK}" GUARD FILE)
+    _find_arm_gnu()
+    file(LOCK "${GBA_TOOLCHAIN_LOCK}" RELEASE)
+    set(toolchain ${ARM_GNU_TOOLCHAIN})
+endif()
 
 if(USE_CLANG)
     _find_clang()
-    message(STATUS "Using ARM GNU toolchain (${ARM_GNU_TOOLCHAIN}) with Clang ${CLANG_C_COMPILER_VERSION}")
+    message(STATUS "Using ARM GNU toolchain (${toolchain}) with Clang ${CLANG_C_COMPILER_VERSION}")
 else()
-    message(STATUS "Using ARM GNU toolchain (${ARM_GNU_TOOLCHAIN}) with GCC ${GNU_C_COMPILER_VERSION}")
+    message(STATUS "Using ARM GNU toolchain (${toolchain}) with GCC ${GNU_C_COMPILER_VERSION}")
 endif()
 
 #====================

--- a/cmake/Gba.cmake
+++ b/cmake/Gba.cmake
@@ -462,10 +462,8 @@ function(_gba_find_gbafix)
         #   *NIX opt/local/
         #   GBA_TOOLCHAIN_TOOLS/tools
         set(searchPaths $ENV{Path})
-        if(USE_DEVKITARM)
-            list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
-            list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
-        endif()
+        list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
+        list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
         list(APPEND searchPaths "${HOST_LOCAL_DIRECTORY}")
         list(APPEND searchPaths "${GBA_TOOLCHAIN_TOOLS}/gbafix")
 
@@ -622,10 +620,8 @@ function(_gba_find_gbfs)
         #   *NIX opt/local/
         #   GBA_TOOLCHAIN_TOOLS/tools
         set(searchPaths $ENV{Path})
-        if(USE_DEVKITARM)
-            list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
-            list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
-        endif()
+        list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
+        list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
         list(APPEND searchPaths "${HOST_LOCAL_DIRECTORY}")
         list(APPEND searchPaths "${GBA_TOOLCHAIN_TOOLS}/gbfs")
 
@@ -725,10 +721,8 @@ function(_gba_find_mmutil)
         #   *NIX opt/local/
         #   GBA_TOOLCHAIN_TOOLS/tools
         set(searchPaths $ENV{Path})
-        if(USE_DEVKITARM)
-            list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
-            list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
-        endif()
+        list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
+        list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
         list(APPEND searchPaths "${HOST_LOCAL_DIRECTORY}")
         list(APPEND searchPaths "${GBA_TOOLCHAIN_TOOLS}/mmutil")
 

--- a/cmake/Gba.cmake
+++ b/cmake/Gba.cmake
@@ -462,6 +462,10 @@ function(_gba_find_gbafix)
         #   *NIX opt/local/
         #   GBA_TOOLCHAIN_TOOLS/tools
         set(searchPaths $ENV{Path})
+        if(USE_DEVKITARM)
+            list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
+            list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
+        endif()
         list(APPEND searchPaths "${HOST_LOCAL_DIRECTORY}")
         list(APPEND searchPaths "${GBA_TOOLCHAIN_TOOLS}/gbafix")
 
@@ -618,6 +622,10 @@ function(_gba_find_gbfs)
         #   *NIX opt/local/
         #   GBA_TOOLCHAIN_TOOLS/tools
         set(searchPaths $ENV{Path})
+        if(USE_DEVKITARM)
+            list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
+            list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
+        endif()
         list(APPEND searchPaths "${HOST_LOCAL_DIRECTORY}")
         list(APPEND searchPaths "${GBA_TOOLCHAIN_TOOLS}/gbfs")
 
@@ -717,6 +725,10 @@ function(_gba_find_mmutil)
         #   *NIX opt/local/
         #   GBA_TOOLCHAIN_TOOLS/tools
         set(searchPaths $ENV{Path})
+        if(USE_DEVKITARM)
+            list(APPEND searchPaths "$ENV{DEVKITPRO}/tools/bin")
+            list(APPEND searchPaths "$ENV{DEVKITARM}/../tools/bin")
+        endif()
         list(APPEND searchPaths "${HOST_LOCAL_DIRECTORY}")
         list(APPEND searchPaths "${GBA_TOOLCHAIN_TOOLS}/mmutil")
 

--- a/cmake/Toolchain.cmake
+++ b/cmake/Toolchain.cmake
@@ -74,6 +74,26 @@ function(_find_arm_gnu)
     set(GNU_CXX_COMPILER_VERSION ${GNU_CXX_COMPILER_VERSION} PARENT_SCOPE)
 endfunction()
 
+function(_find_devkitarm)
+    find_program(GNU_C_COMPILER NAMES "arm-none-eabi-gcc" PATHS "$ENV{DEVKITARM}/bin")
+    find_program(GNU_CXX_COMPILER NAMES "arm-none-eabi-g++" PATHS "$ENV{DEVKITARM}/bin")
+    find_program(GNU_OBJCOPY NAMES "arm-none-eabi-objcopy" PATHS "$ENV{DEVKITARM}/bin")
+    find_program(GNU_AR NAMES "arm-none-eabi-ar" PATHS "$ENV{DEVKITARM}/bin")
+    find_program(GNU_RANLIB NAMES "arm-none-eabi-ranlib" PATHS "$ENV{DEVKITARM}/bin")
+    find_program(GNU_NM NAMES "arm-none-eabi-nm" PATHS "$ENV{DEVKITARM}/bin")
+    find_program(GNU_OBJDUMP NAMES "arm-none-eabi-objdump" PATHS "$ENV{DEVKITARM}/bin")
+    find_program(GNU_STRIP NAMES "arm-none-eabi-strip" PATHS "$ENV{DEVKITARM}/bin")
+
+    # Detect compiler versions
+    execute_process(COMMAND "${GNU_C_COMPILER}" -dumpversion OUTPUT_VARIABLE GNU_C_COMPILER_VERSION)
+    string(STRIP "${GNU_C_COMPILER_VERSION}" GNU_C_COMPILER_VERSION)
+    set(GNU_C_COMPILER_VERSION ${GNU_C_COMPILER_VERSION} PARENT_SCOPE)
+
+    execute_process(COMMAND "${GNU_CXX_COMPILER}" -dumpversion OUTPUT_VARIABLE GNU_CXX_COMPILER_VERSION)
+    string(STRIP "${GNU_CXX_COMPILER_VERSION}" GNU_CXX_COMPILER_VERSION)
+    set(GNU_CXX_COMPILER_VERSION ${GNU_CXX_COMPILER_VERSION} PARENT_SCOPE)
+endfunction()
+
 #! _find_clang : Locates Clang
 #
 function(_find_clang)
@@ -102,6 +122,7 @@ function(_configure_toolchain)
     # Docstrings
     #====================
 
+    set(DOCSTRING_CMAKE_ASM_FLAGS               "Flags used by the Assembler compiler during all build types.")
     set(DOCSTRING_CMAKE_C_FLAGS                 "Flags used by the C compiler during all build types.")
     set(DOCSTRING_CMAKE_CXX_FLAGS               "Flags used by the C++ compiler during all build types.")
     set(DOCSTRING_CMAKE_C_FLAGS_MINSIZEREL      "Flags used by the C compiler during MINSIZEREL builds.")
@@ -123,15 +144,30 @@ function(_configure_toolchain)
     set(SHARED_CXX_FLAGS "-mabi=aapcs -march=armv4t -mcpu=arm7tdmi -fno-exceptions") # nano is not compiled with C++ exceptions
 
     if(USE_CLANG)
-        include_directories(SYSTEM
-            ${ARM_GNU_TOOLCHAIN}/lib/gcc/arm-none-eabi/${GNU_C_COMPILER_VERSION}/include
-            ${ARM_GNU_TOOLCHAIN}/arm-none-eabi/include/c++/${GNU_CXX_COMPILER_VERSION}
-            ${ARM_GNU_TOOLCHAIN}/arm-none-eabi/include/c++/${GNU_CXX_COMPILER_VERSION}/arm-none-eabi
-        )
+        if(USE_DEVKITARM)
+            set(toolchain $ENV{DEVKITARM})
+        else()
+            set(toolchain ${ARM_GNU_TOOLCHAIN})
+        endif()
+
+        if(USE_DEVKITARM)
+            include_directories(SYSTEM
+                ${toolchain}/arm-none-eabi/include/c++
+                ${toolchain}/arm-none-eabi/include/c++/${GNU_CXX_COMPILER_VERSION}
+                ${toolchain}/arm-none-eabi/include
+                ${toolchain}/arm-none-eabi
+            )
+        else()
+            include_directories(SYSTEM
+                ${toolchain}/lib/gcc/arm-none-eabi/${GNU_C_COMPILER_VERSION}/include
+                ${toolchain}/arm-none-eabi/include/c++/${GNU_CXX_COMPILER_VERSION}
+                ${toolchain}/arm-none-eabi/include/c++/${GNU_CXX_COMPILER_VERSION}/arm-none-eabi
+            )
+        endif()
 
         # Flags for all build types
-        set(CMAKE_C_FLAGS_INIT "${SHARED_C_FLAGS} --target=arm-arm-none-eabi -isystem \"${ARM_GNU_TOOLCHAIN}/arm-none-eabi/include\"" CACHE STRING "${DOCSTRING_CMAKE_C_FLAGS}" FORCE)
-        set(CMAKE_CXX_FLAGS_INIT "${SHARED_CXX_FLAGS} --target=arm-arm-none-eabi -isystem \"${ARM_GNU_TOOLCHAIN}/arm-none-eabi/include\"" CACHE STRING "${DOCSTRING_CMAKE_CXX_FLAGS}" FORCE)
+        set(CMAKE_C_FLAGS_INIT "${SHARED_C_FLAGS} --target=arm-arm-none-eabi -isystem \"${toolchain}/arm-none-eabi/include\"" CACHE STRING "${DOCSTRING_CMAKE_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS_INIT "${SHARED_CXX_FLAGS} --target=arm-arm-none-eabi -isystem \"${toolchain}/arm-none-eabi/include\"" CACHE STRING "${DOCSTRING_CMAKE_CXX_FLAGS}")
 
         # Flags for MinSizeRel
         set(CMAKE_C_FLAGS_MINSIZEREL_INIT "-Oz -DNDEBUG" CACHE STRING "${DOCSTRING_CMAKE_C_FLAGS_MINSIZEREL}")
@@ -176,9 +212,13 @@ function(_configure_toolchain)
     # Linkers
     #====================
 
-    # Unfortunately ARM GNU toolchain compiles with short enums
-    # This causes a 32-bit enum warning to be emitted, even if all binaries use 32-bit enums
-    set(CMAKE_EXE_LINKER_FLAGS_INIT "-L\"${ARM_GNU_TOOLCHAIN}/arm-none-eabi/lib/thumb/nofp\" -Xlinker -no-enum-size-warning" CACHE INTERNAL "" FORCE)
+    if(USE_DEVKITARM)
+        set(CMAKE_EXE_LINKER_FLAGS_INIT "-L\"$ENV{DEVKITARM}/arm-none-eabi/lib/thumb\"" CACHE INTERNAL "" FORCE)
+    else()
+        # Unfortunately ARM GNU toolchain compiles with short enums
+        # This causes a 32-bit enum warning to be emitted, even if all binaries use 32-bit enums
+        set(CMAKE_EXE_LINKER_FLAGS_INIT "-L\"${ARM_GNU_TOOLCHAIN}/arm-none-eabi/lib/thumb/nofp\" -Xlinker -no-enum-size-warning" CACHE INTERNAL "" FORCE)
+    endif()
 
     set(CMAKE_LINKER "${GNU_C_COMPILER}" CACHE FILEPATH "Path to ld.")
     set(CMAKE_SHARED_LINKER "${GNU_C_COMPILER}" CACHE FILEPATH "Path to ld for shared linking.")

--- a/lib/ereader/CMakeLists.txt
+++ b/lib/ereader/CMakeLists.txt
@@ -25,8 +25,15 @@ target_compile_options(ereader PRIVATE
 )
 target_link_options(ereader PRIVATE -Wl,--gc-sections)
 
+if(USE_DEVKITARM)
+    target_compile_definitions(ereader PUBLIC __DEVKITARM__)
+    set(specs "${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-devkitarm.specs")
+else()
+    set(specs "${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-nano.specs")
+endif()
+
 target_link_options(ereader INTERFACE
     -T ${CMAKE_CURRENT_LIST_DIR}/../ldscripts/ereader.ld
-    -specs=${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-nano.specs
+    -specs=${specs}
     -B ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/lib/gba-runtime-devkitarm.specs
+++ b/lib/gba-runtime-devkitarm.specs
@@ -1,0 +1,11 @@
+#===============================================================================
+#
+# Spec file for devkitARM toolchain
+#
+# Copyright (C) 2021-2022 gba-toolchain contributors
+# For conditions of distribution and use, see copyright notice in LICENSE.md
+#
+#===============================================================================
+
+*startfile:
+  libruntime.a%s

--- a/lib/gba-runtime-nosyscalls.c
+++ b/lib/gba-runtime-nosyscalls.c
@@ -14,6 +14,9 @@
 
 #undef errno
 extern int errno;
+#if defined(__DEVKITARM__)
+int errno; // devkitARM lacks errno
+#endif
 
 #define EWRAM_TOP 0x2040000
 
@@ -33,6 +36,13 @@ char* _sbrk(int incr) {
     heap_end += incr;
     return prev_heap_end;
 }
+
+#if defined(__DEVKITARM__)
+// devkitARM uses _sbrk_r
+char* _sbrk_r(__attribute__((unused)) void* reent, int incr) {
+    return _sbrk(incr);
+}
+#endif
 
 static int _gba_nosys() {
     errno = ENOSYS;

--- a/lib/multiboot/CMakeLists.txt
+++ b/lib/multiboot/CMakeLists.txt
@@ -25,8 +25,15 @@ target_compile_options(multiboot PRIVATE
 )
 target_link_options(multiboot PRIVATE -Wl,--gc-sections)
 
+if(USE_DEVKITARM)
+    target_compile_definitions(multiboot PUBLIC __DEVKITARM__)
+    set(specs "${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-devkitarm.specs")
+else()
+    set(specs "${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-nano.specs")
+endif()
+
 target_link_options(multiboot INTERFACE
     -T ${CMAKE_CURRENT_LIST_DIR}/../ldscripts/multiboot.ld
-    -specs=${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-nano.specs
+    -specs=${specs}
     -B ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/lib/rom/CMakeLists.txt
+++ b/lib/rom/CMakeLists.txt
@@ -19,8 +19,15 @@ target_compile_options(rom PRIVATE
 )
 target_link_options(rom PRIVATE -Wl,--gc-sections)
 
+if(USE_DEVKITARM)
+    target_compile_definitions(rom PUBLIC __DEVKITARM__)
+    set(specs "${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-devkitarm.specs")
+else()
+    set(specs "${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-nano.specs")
+endif()
+
 target_link_options(rom INTERFACE
     -T ${CMAKE_CURRENT_LIST_DIR}/../ldscripts/rom.ld
-    -specs=${CMAKE_CURRENT_LIST_DIR}/../gba-runtime-nano.specs
+    -specs=${specs}
     -B ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/samples/04 ereader/CMakeLists.txt
+++ b/samples/04 ereader/CMakeLists.txt
@@ -11,6 +11,10 @@ cmake_minimum_required(VERSION 3.18)
 
 project(sample-ereader C)
 
+if(USE_DEVKITARM)
+    message(WARNING "e-Reader programs cannot exit to ROM with USE_DEVKITARM")
+endif()
+
 gba_add_library_subdirectory(ereader tonc)
 
 add_executable(helloDotCode main.c)

--- a/samples/11 Linker script/CMakeLists.txt
+++ b/samples/11 Linker script/CMakeLists.txt
@@ -12,6 +12,10 @@ cmake_minimum_required(VERSION 3.18)
 
 project(linker-script-sample ASM C CXX)
 
+if(USE_DEVKITARM)
+    message(FATAL_ERROR "This sample is not compatible with USE_DEVKITARM")
+endif()
+
 gba_add_library_subdirectory(tonc)
 
 add_executable(helloLinker crt0.s syscalls.c main.cpp)


### PR DESCRIPTION
This has been requested a fair bit

- devkitARM tools are now searched by default (should save needlessly compiling tools if they're on your disk already)

Configure with `-DUSE_DEVKITARM=ON` to enable. If enabled:

- GNU Arm Embedded Toolchain won't be downloaded 
- devkitARM builds of GCC and associated headers and libraries will be used
- The macro `__DEVKITARM__` is defined (used by `librom`, `libmultiboot`, `libereader` for DKA compatibility)

Do note: `devkitARM` uses reentrant implementations of C and POSIX APIs, which results in a larger binary and potentially reduced runtime performance.

This does **NOT** use devkitARM linker scripts or `crt0.s`.