### PR TITLE
fetch libseven and minrt from sdk-seven, fetch libtonc from gbadev-org

### DIFF
--- a/cmake/MinrtCMakeLists.cmake
+++ b/cmake/MinrtCMakeLists.cmake
@@ -11,11 +11,11 @@ cmake_minimum_required(VERSION 3.0)
 
 project(gba-minrt ASM)
 
-add_library(gba-minrt STATIC rt/crt0.s)
+add_library(gba-minrt STATIC src/crt0.s)
 
 target_link_options(gba-minrt INTERFACE
     -mthumb
-    -nostartfiles
+    -specs=lib/nocrt0.specs
     -specs=nano.specs -specs=nosys.specs
-    -Wl,-T,${CMAKE_CURRENT_LIST_DIR}/rt/rom.ld -L${CMAKE_CURRENT_LIST_DIR}/rt
+    -Wl,-T,${CMAKE_CURRENT_LIST_DIR}/lib/rom.ld -L${CMAKE_CURRENT_LIST_DIR}/lib
 )

--- a/dependencies.ini
+++ b/dependencies.ini
@@ -26,8 +26,8 @@ url = https://raw.githubusercontent.com/devkitPro/gba-tools/054d507f90d32784274b
 md5 = 9A4D72B137658A3732E3041DE1B54F4F
 
 [tonclib]
-url = https://github.com/devkitPro/libtonc/archive/ccc03fa321e56f51aed5e2ee1d6e3df3d1cbc803.zip
-md5 = e72af298d4d1adee72c4129249d383cf
+url = https://github.com/gbadev-org/libtonc/archive/cc862ceb8b7151f1125b6ce629925be6e54827c3.zip
+md5 = 866FAEF359B19B68BFB4DE213D1F6758
 
 [libseven]
 url = https://github.com/LunarLambda/sdk-seven/releases/download/v0.1.1/libseven-0.7.1.zip

--- a/dependencies.ini
+++ b/dependencies.ini
@@ -30,7 +30,7 @@ url = https://github.com/devkitPro/libtonc/archive/ccc03fa321e56f51aed5e2ee1d6e3
 md5 = e72af298d4d1adee72c4129249d383cf
 
 [libseven]
-url = https://github.com/LunarLambda/libseven/archive/refs/heads/main.zip
+url = https://github.com/LunarLambda/sdk-seven/releases/download/libseven-0.7.0/libseven-0.7.0.zip
 ; no md5 because libseven is in active development
 
 [nedclib]
@@ -62,5 +62,5 @@ url = https://github.com/felixjones/gba-hpp/archive/refs/heads/main.zip
 md5 = 20db830b2901365242ddf959a48e231f
 
 [gba-minrt]
-url = https://github.com/LunarLambda/gba-minrt/archive/refs/heads/main.zip
+url = https://github.com/LunarLambda/sdk-seven/releases/download/minrt-0.1.0/minrt-0.1.0.zip
 ; no md5 because gba-minrt is in active development

--- a/dependencies.ini
+++ b/dependencies.ini
@@ -30,7 +30,7 @@ url = https://github.com/devkitPro/libtonc/archive/ccc03fa321e56f51aed5e2ee1d6e3
 md5 = e72af298d4d1adee72c4129249d383cf
 
 [libseven]
-url = https://github.com/LunarLambda/sdk-seven/releases/download/libseven-0.7.0/libseven-0.7.0.zip
+url = https://github.com/LunarLambda/sdk-seven/releases/download/v0.1.1/libseven-0.7.1.zip
 ; no md5 because libseven is in active development
 
 [nedclib]
@@ -62,5 +62,5 @@ url = https://github.com/felixjones/gba-hpp/archive/refs/heads/main.zip
 md5 = 20db830b2901365242ddf959a48e231f
 
 [gba-minrt]
-url = https://github.com/LunarLambda/sdk-seven/releases/download/minrt-0.1.0/minrt-0.1.0.zip
+url = https://github.com/LunarLambda/sdk-seven/releases/download/v0.1.1/minrt-0.1.1.zip
 ; no md5 because gba-minrt is in active development


### PR DESCRIPTION
libseven and gba-minrt have moved to a new repository: https://github.com/LunarLambda/sdk-seven

gbadev-org has started maintenance forks of libgba and libtonc. https://github.com/gbadev-org/libtonc

due to the new project structure, individual source archives are published through github releases.

I also updated the cmakelists for minrt, since the folder structures have changed. if anything else needs fixing, let me know.