### PR TITLE
Fix superfamiconv map generation

### DIFF
--- a/cmake/Modules/Findsuperfamiconv.cmake
+++ b/cmake/Modules/Findsuperfamiconv.cmake
@@ -168,7 +168,7 @@ function(add_superfamiconv_graphics target)
         add_custom_command(
             OUTPUT ${mapOutputs}
             DEPENDS ${ARGS_UNPARSED_ARGUMENTS} ${tilesOutputs} ${paletteOutputs}
-            COMMAND "${CMAKE_COMMAND}" -DTILES=ON
+            COMMAND "${CMAKE_COMMAND}" -DMAP=ON
                 "-DPROGRAM=${CMAKE_SUPERFAMICONV_PROGRAM}"
                 "-DPREFIX=${CMAKE_BINARY_DIR}/"
                 -DSUFFIX=.map


### PR DESCRIPTION
The superfamiconv call for maps generates tiles instead of generating a map.

Btw, thank you for creating this! 👍 I was able to compile my first GBA program in no time using gba-toolchain.