### PR TITLE
Use CMAKE_CURRENT_BINARY_DIR instead of CMAKE_BINARY_DIR

### DIFF
--- a/cmake/Modules/Findbutano.cmake
+++ b/cmake/Modules/Findbutano.cmake
@@ -140,7 +140,7 @@ function(add_butano_assets target)
     )
     cmake_parse_arguments(ARGS "" "" "${multiValueArgs}" ${ARGN})
 
-    set(binaryDir "${CMAKE_BINARY_DIR}/butano_${target}_assets")
+    set(binaryDir "${CMAKE_CURRENT_BINARY_DIR}/butano_${target}_assets")
 
     # Add audio outputs
     if(ARGS_AUDIO)
@@ -198,7 +198,7 @@ function(add_butano_assets target)
             --graphics="${ARGS_GRAPHICS}"
             --build="${binaryDir}"
         COMMAND ${bin2sCommand} "${binaryDir}/_bn_audio_soundbank.bin" > "${binaryDir}/_bn_audio_soundbank.s"
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 
     add_library(${target} OBJECT ${outputs})

--- a/cmake/Modules/Findgbfs.cmake
+++ b/cmake/Modules/Findgbfs.cmake
@@ -173,8 +173,8 @@ function(add_gbfs_archive target)
 
     add_custom_command(
         OUTPUT ${target}.gbfs ${target}.s
-        COMMAND "${CMAKE_GBFS_PROGRAM}" "${CMAKE_BINARY_DIR}/${target}.gbfs" ${ASSETS}
-        COMMAND "${CMAKE_BIN2S_PROGRAM}" "${CMAKE_BINARY_DIR}/${target}.gbfs" > "${CMAKE_BINARY_DIR}/${target}.s"
+        COMMAND "${CMAKE_GBFS_PROGRAM}" "${CMAKE_CURRENT_BINARY_DIR}/${target}.gbfs" ${ASSETS}
+        COMMAND "${CMAKE_BIN2S_PROGRAM}" "${CMAKE_CURRENT_BINARY_DIR}/${target}.gbfs" > "${CMAKE_CURRENT_BINARY_DIR}/${target}.s"
         DEPENDS ${ASSETS}
         VERBATIM
         COMMAND_EXPAND_LISTS
@@ -183,11 +183,11 @@ function(add_gbfs_archive target)
 
     add_library(${target} OBJECT ${target}.s)
 
-    install(FILES "${CMAKE_BINARY_DIR}/${target}.gbfs" DESTINATION .)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}.gbfs" DESTINATION .)
 
     set_target_properties(${target} PROPERTIES
         ASSETS "${ARGN}"
-        GBFS_FILE "${CMAKE_BINARY_DIR}/${target}.gbfs"
+        GBFS_FILE "${CMAKE_CURRENT_BINARY_DIR}/${target}.gbfs"
     )
 endfunction()
 

--- a/cmake/Modules/Findgbfs.cmake
+++ b/cmake/Modules/Findgbfs.cmake
@@ -178,7 +178,7 @@ function(add_gbfs_archive target)
         DEPENDS ${ASSETS}
         VERBATIM
         COMMAND_EXPAND_LISTS
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
 
     add_library(${target} OBJECT ${target}.s)

--- a/cmake/Modules/Findgbt-player.cmake
+++ b/cmake/Modules/Findgbt-player.cmake
@@ -107,17 +107,17 @@ function(add_gbt_assets target)
                 COMMAND "${CMAKE_COMMAND}" -E env "${Python_EXECUTABLE}" "${s3m2gbt}"
                     --input "${input}"
                     --name "${target}_${name}"
-                    --output "${CMAKE_BINARY_DIR}/${output}"
+                    --output "${CMAKE_CURRENT_BINARY_DIR}/${output}"
                     --instruments
-                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             )
         elseif(ext STREQUAL ".mod")
             add_custom_command(
                 OUTPUT "${output}"
                 COMMAND "${CMAKE_COMMAND}" -E env "${Python_EXECUTABLE}" "${mod2gbt}"
-                    "${CMAKE_SOURCE_DIR}/${input}" "${target}_${name}"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/${input}" "${target}_${name}"
                 COMMAND "${CMAKE_COMMAND}" -E rename "${target}_${output}" "${output}"
-                WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+                WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
             )
         else()
             message(FATAL_ERROR "${input} must be .s3m or .mod format")
@@ -143,14 +143,14 @@ function(add_gbt_maxmod_assets target)
                 BYPRODUCTS "${name}_psg.s3m"
                 COMMAND "${CMAKE_COMMAND}" -E env "${Python_EXECUTABLE}" "${s3msplit}"
                     --input "${input}"
-                    --psg "${CMAKE_BINARY_DIR}/${name}_psg.s3m"
-                    --dma "${CMAKE_BINARY_DIR}/${name}_dma.s3m"
+                    --psg "${CMAKE_CURRENT_BINARY_DIR}/${name}_psg.s3m"
+                    --dma "${CMAKE_CURRENT_BINARY_DIR}/${name}_dma.s3m"
                 COMMAND "${CMAKE_COMMAND}" -E env "${Python_EXECUTABLE}" "${s3m2gbt}"
-                    --input "${CMAKE_BINARY_DIR}/${name}_psg.s3m"
+                    --input "${CMAKE_CURRENT_BINARY_DIR}/${name}_psg.s3m"
                     --name "${target}_${name}"
-                    --output "${CMAKE_BINARY_DIR}/${output}"
+                    --output "${CMAKE_CURRENT_BINARY_DIR}/${output}"
                     --instruments
-                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             )
             list(APPEND outputs ${output})
             list(APPEND dma "${name}_dma.s3m")
@@ -172,9 +172,9 @@ function(add_gbt_maxmod_assets target)
         COMMAND "${CMAKE_COMMAND}" -E make_directory "soundbank"
         COMMAND "${CMAKE_MMUTIL_PROGRAM}" -o${target}.bin -hsoundbank/${target}.h ${dma}
         COMMAND ${bin2sCommand}  "${target}.bin" > "${target}.s"
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )
 
     add_library(${target} OBJECT ${outputs} "${target}.s")
-    target_include_directories(${target} INTERFACE ${CMAKE_BINARY_DIR})
+    target_include_directories(${target} INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 endfunction()

--- a/cmake/Modules/Findgrit.cmake
+++ b/cmake/Modules/Findgrit.cmake
@@ -130,8 +130,8 @@ if(NOT CMAKE_GRIT_PROGRAM)
 endif()
 
 function(add_grit_tilemap target type)
-    file(RELATIVE_PATH inpath "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
-    set(outpath "${CMAKE_BINARY_DIR}")
+    file(RELATIVE_PATH inpath "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
+    set(outpath "${CMAKE_CURRENT_BINARY_DIR}")
 
     set(oneValueArgs
         SHARED_PREFIX # File to use for shared output (default is target name when sharing is used)
@@ -301,14 +301,14 @@ function(add_grit_tilemap target type)
         COMMAND "${CMAKE_GRIT_PROGRAM}" ${input} ${opts}
         DEPENDS ${input}
         VERBATIM
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )
 
     # Setup the target
 
     if(type STREQUAL C OR type STREQUAL ASM)
         add_library(${target} OBJECT ${output})
-        target_include_directories(${target} INTERFACE "${CMAKE_BINARY_DIR}")
+        target_include_directories(${target} INTERFACE "${CMAKE_CURRENT_BINARY_DIR}")
     else()
         add_custom_target(${target} DEPENDS ${output})
         set_target_properties(${target} PROPERTIES OBJECTS "${output}")
@@ -321,8 +321,8 @@ function(add_grit_sprite target type)
 endfunction()
 
 function(add_grit_bitmap target type)
-    file(RELATIVE_PATH inpath "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
-    set(outpath "${CMAKE_BINARY_DIR}")
+    file(RELATIVE_PATH inpath "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
+    set(outpath "${CMAKE_CURRENT_BINARY_DIR}")
 
     set(oneValueArgs
         SHARED_PREFIX # File to use for shared output (default is target name when sharing is used)
@@ -468,14 +468,14 @@ function(add_grit_bitmap target type)
         COMMAND "${CMAKE_GRIT_PROGRAM}" ${input} ${opts}
         DEPENDS ${input}
         VERBATIM
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )
 
     # Setup the target
 
     if(type STREQUAL C OR type STREQUAL ASM)
         add_library(${target} OBJECT ${output})
-        target_include_directories(${target} INTERFACE "${CMAKE_BINARY_DIR}")
+        target_include_directories(${target} INTERFACE "${CMAKE_CURRENT_BINARY_DIR}")
     else()
         add_custom_target(${target} DEPENDS ${output})
         set_target_properties(${target} PROPERTIES OBJECTS "${output}")

--- a/cmake/Modules/Findgrit.cmake
+++ b/cmake/Modules/Findgrit.cmake
@@ -130,7 +130,7 @@ if(NOT CMAKE_GRIT_PROGRAM)
 endif()
 
 function(add_grit_tilemap target type)
-    file(RELATIVE_PATH inpath "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
+    file(RELATIVE_PATH inpath "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
     set(outpath "${CMAKE_CURRENT_BINARY_DIR}")
 
     set(oneValueArgs
@@ -321,7 +321,7 @@ function(add_grit_sprite target type)
 endfunction()
 
 function(add_grit_bitmap target type)
-    file(RELATIVE_PATH inpath "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_SOURCE_DIR}")
+    file(RELATIVE_PATH inpath "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
     set(outpath "${CMAKE_CURRENT_BINARY_DIR}")
 
     set(oneValueArgs

--- a/cmake/Modules/Findmaxmod.cmake
+++ b/cmake/Modules/Findmaxmod.cmake
@@ -190,19 +190,19 @@ function(add_maxmod_soundbank target)
 
     add_custom_command(
         OUTPUT ${target}.bin soundbank/${target}.h
-        COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/soundbank"
-        COMMAND "${CMAKE_MMUTIL_PROGRAM}" -o${CMAKE_BINARY_DIR}/${target}.bin -h${CMAKE_BINARY_DIR}/soundbank/${target}.h ${ASSETS}
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/soundbank"
+        COMMAND "${CMAKE_MMUTIL_PROGRAM}" -o${CMAKE_CURRENT_BINARY_DIR}/${target}.bin -h${CMAKE_CURRENT_BINARY_DIR}/soundbank/${target}.h ${ASSETS}
         DEPENDS ${ASSETS}
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         VERBATIM
         COMMAND_EXPAND_LISTS
     )
 
     add_library(${target} INTERFACE)
-    target_include_directories(${target} INTERFACE ${CMAKE_BINARY_DIR})
+    target_include_directories(${target} INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 
     set_target_properties(${target} PROPERTIES
         ASSETS "${ARGN}"
-        BIN_FILE "${CMAKE_BINARY_DIR}/${target}.bin"
+        BIN_FILE "${CMAKE_CURRENT_BINARY_DIR}/${target}.bin"
     )
 endfunction()

--- a/cmake/Modules/Findsuperfamiconv.cmake
+++ b/cmake/Modules/Findsuperfamiconv.cmake
@@ -123,11 +123,11 @@ function(add_superfamiconv_graphics target)
             DEPENDS ${ARGS_UNPARSED_ARGUMENTS}
             COMMAND "${CMAKE_COMMAND}" -DPALETTE=ON
                 "-DPROGRAM=${CMAKE_SUPERFAMICONV_PROGRAM}"
-                "-DPREFIX=${CMAKE_BINARY_DIR}/"
+                "-DPREFIX=${CMAKE_CURRENT_BINARY_DIR}/"
                 -DSUFFIX=.palette
                 "-DINPUTS=${ARGS_UNPARSED_ARGUMENTS}"
                 -P "${SUPERFAMICONV_SCRIPT}"
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             VERBATIM
         )
     endif()
@@ -146,13 +146,13 @@ function(add_superfamiconv_graphics target)
             COMMAND "${CMAKE_COMMAND}" -DTILES=ON
                 "-DPROGRAM=${CMAKE_SUPERFAMICONV_PROGRAM}"
                 "-DPARAMS=$<IF:$<BOOL:${ARGS_SPRITE_MODE}>,--no-discard,${ARGS_TILES}>"
-                "-DPREFIX=${CMAKE_BINARY_DIR}/"
+                "-DPREFIX=${CMAKE_CURRENT_BINARY_DIR}/"
                 -DSUFFIX=.tiles
-                "-DPREFIX_PALETTE=${CMAKE_BINARY_DIR}/"
+                "-DPREFIX_PALETTE=${CMAKE_CURRENT_BINARY_DIR}/"
                 -DSUFFIX_PALETTE=.palette
                 "-DINPUTS=${ARGS_UNPARSED_ARGUMENTS}"
                 -P "${SUPERFAMICONV_SCRIPT}"
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             VERBATIM
         )
     endif()
@@ -170,15 +170,15 @@ function(add_superfamiconv_graphics target)
             DEPENDS ${ARGS_UNPARSED_ARGUMENTS} ${tilesOutputs} ${paletteOutputs}
             COMMAND "${CMAKE_COMMAND}" -DMAP=ON
                 "-DPROGRAM=${CMAKE_SUPERFAMICONV_PROGRAM}"
-                "-DPREFIX=${CMAKE_BINARY_DIR}/"
+                "-DPREFIX=${CMAKE_CURRENT_BINARY_DIR}/"
                 -DSUFFIX=.map
-                "-DPREFIX_PALETTE=${CMAKE_BINARY_DIR}/"
+                "-DPREFIX_PALETTE=${CMAKE_CURRENT_BINARY_DIR}/"
                 -DSUFFIX_PALETTE=.palette
-                "-DPREFIX_TILES=${CMAKE_BINARY_DIR}/"
+                "-DPREFIX_TILES=${CMAKE_CURRENT_BINARY_DIR}/"
                 -DSUFFIX_TILES=.tiles
                 "-DINPUTS=${ARGS_UNPARSED_ARGUMENTS}"
                 -P "${SUPERFAMICONV_SCRIPT}"
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             VERBATIM
         )
     endif()
@@ -187,7 +187,7 @@ function(add_superfamiconv_graphics target)
 
     set(binaryOutput)
     foreach(output ${outputs})
-        list(APPEND binaryOutput "${CMAKE_BINARY_DIR}/${output}")
+        list(APPEND binaryOutput "${CMAKE_CURRENT_BINARY_DIR}/${output}")
     endforeach()
 
     set_target_properties(${target} PROPERTIES

--- a/cmake/Platform/AdvancedGameBoy.cmake
+++ b/cmake/Platform/AdvancedGameBoy.cmake
@@ -150,9 +150,9 @@ function(add_asset_library target)
 
     add_custom_command(
         OUTPUT ${target}.s
-        COMMAND ${bin2sCommand} "${assetsEval}" > "${CMAKE_BINARY_DIR}/${target}.s"
+        COMMAND ${bin2sCommand} "${assetsEval}" > "${CMAKE_CURRENT_BINARY_DIR}/${target}.s"
         DEPENDS ${assetsEval}
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         COMMAND_EXPAND_LISTS
     )
 


### PR DESCRIPTION
In a few cases there's functions to add cmake custom targets that use the root `CMAKE_SOURCE_DIR`/`CMAKE_BINARY_DIR` for output directories and working directories. This works if all the targets are declared in the root `CMakeLists.txt`, but not if they're in subdirectory `CMakeLists.txt` added with `add_subdirectory`. Should this instead be using `CMAKE_CURRENT_SOURCE_DIR`/`CMAKE_CURRENT_BINARY_DIR`?