### PR TITLE
Fix finding picolibc

### DIFF
--- a/cmake/Modules/Platform/AdvancedGameBoy-Common.cmake
+++ b/cmake/Modules/Platform/AdvancedGameBoy-Common.cmake
@@ -41,13 +41,13 @@ execute_process(
         OUTPUT_VARIABLE picolibc
 )
 string(REGEX MATCH "libraries:[ \t]=*([^\r\n]*)" picolibc "${picolibc}" )
-set(picolibc "${CMAKE_MATCH_1}")
+unset(picolibc)
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Linux)
-    string(REPLACE ":" ";" picolibc "${picolibc}")
+    string(REPLACE ":" ";" CMAKE_MATCH_1 "${CMAKE_MATCH_1}")
 endif()
 find_file(picolibc
         NAMES picolibc.specs
-        PATHS ${picolibc}
+        PATHS ${CMAKE_MATCH_1}
 )
 if(picolibc)
     set(PICOLIBC 1)


### PR DESCRIPTION
Looks like `picolibc` is NOT set to `picolibc-NOTFOUND` on `find_file(...)` when it's already set, so we need to `unset(picolibc)`.

This fixes devkitARM build failing with error below:
```bash
<omitted...> CMakeFiles/butano_fighter.dir/src/main.cpp.obj -o butano_fighter.elf  lib/rom/librom.a && :
arm-none-eabi-g++: fatal error: cannot read spec file 'picolibc.specs': No such file or directory
compilation terminated.
ninja: build stopped: subcommand failed.
```