### PR TITLE
Fix CMake 3.30

### DIFF
--- a/cmake/Platform/AdvancedGameBoy-GNU-C.cmake
+++ b/cmake/Platform/AdvancedGameBoy-GNU-C.cmake
@@ -6,8 +6,14 @@
 #===============================================================================
 
 include(Compiler/CMakeCommonCompilerMacros)
-include(${CMAKE_ROOT}/Modules/CMakeDetermineCompileFeatures.cmake)
-cmake_determine_compile_features(C)
+
+if(CMAKE_VERSION VERSION_LESS "3.30.0")
+    include(${CMAKE_ROOT}/Modules/CMakeDetermineCompileFeatures.cmake)
+    cmake_determine_compile_features(C)
+else()
+    include(${CMAKE_ROOT}/Modules/CMakeDetermineCompilerSupport.cmake)
+    cmake_determine_compiler_support(C)
+endif()
 
 set(CMAKE_C_FLAGS_RELEASE_INIT          "-O3 -DNDEBUG")
 set(CMAKE_C_FLAGS_DEBUG_INIT            "-O0 -g -D_DEBUG")

--- a/cmake/Platform/AdvancedGameBoy-GNU-CXX.cmake
+++ b/cmake/Platform/AdvancedGameBoy-GNU-CXX.cmake
@@ -6,8 +6,14 @@
 #===============================================================================
 
 include(Compiler/CMakeCommonCompilerMacros)
-include(${CMAKE_ROOT}/Modules/CMakeDetermineCompileFeatures.cmake)
-cmake_determine_compile_features(CXX)
+
+if(CMAKE_VERSION VERSION_LESS "3.30.0")
+    include(${CMAKE_ROOT}/Modules/CMakeDetermineCompileFeatures.cmake)
+    cmake_determine_compile_features(CXX)
+else()
+    include(${CMAKE_ROOT}/Modules/CMakeDetermineCompilerSupport.cmake)
+    cmake_determine_compiler_support(CXX)
+endif()
 
 set(CMAKE_CXX_FLAGS_RELEASE_INIT        "-O3 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG_INIT          "-O0 -g -D_DEBUG")


### PR DESCRIPTION
CMakeDetermineCompileFeatures and the function it contains were renamed in CMake 3.30. Not sure if this is the best solution, but it works.

(https://gitlab.kitware.com/cmake/cmake/-/commit/588371d2d5fdda0340b29058147f49e40723ba71)