### PR TITLE
Copy devkitarm PR, overlays are fighting over LMA ranges

### DIFF
--- a/lib/rom/rom.ld
+++ b/lib/rom/rom.ld
@@ -122,11 +122,13 @@ SECTIONS {
     } > iwram
 
     PROVIDE_HIDDEN(__iwram_start = ALIGN(4));
-    PROVIDE_HIDDEN(__iwram_lma = ALIGN(__iwram_overlay_lma + (. - __iwram_overlay_start), 32));
+    PROVIDE_HIDDEN(__iwram_lma = ALIGN(__iwram_overlay_lma + SIZEOF(.iwram0) + SIZEOF(.iwram1) + SIZEOF(.iwram2) +
+            SIZEOF(.iwram3) + SIZEOF(.iwram4) + SIZEOF(.iwram5) + SIZEOF(.iwram6) +
+            SIZEOF(.iwram7) + SIZEOF(.iwram8) + SIZEOF(.iwram9), 32));
 
     .iwram : AT(__iwram_lma) {
         KEEP(*(SORT(.iwram.sorted.*)))
-        *(.iwram .iwram.*)
+        *(.iwram)
         *.iwram.*(.data .data.* .text .text.*)
         *(.data .data.* .gnu.linkonce.d.*)
         . = ALIGN(32);

--- a/lib/rom/rom.ld
+++ b/lib/rom/rom.ld
@@ -80,7 +80,9 @@ SECTIONS {
     } > ewram
 
     PROVIDE_HIDDEN(__ewram_start = ALIGN(4));
-    PROVIDE_HIDDEN(__ewram_lma = ALIGN(__ewram_overlay_lma + (. - __ewram_overlay_start), 4));
+    PROVIDE_HIDDEN(__ewram_lma = ALIGN(__ewram_overlay_lma + SIZEOF(.ewram0) + SIZEOF(.ewram1) + SIZEOF(.ewram2) +
+                SIZEOF(.ewram3) + SIZEOF(.ewram4) + SIZEOF(.ewram5) + SIZEOF(.ewram6) +
+                SIZEOF(.ewram7) + SIZEOF(.ewram8) + SIZEOF(.ewram9), 4));
 
     .ewram : AT(__ewram_lma) ALIGN(32) {
         KEEP(*(SORT(.ewram.sorted.*)))
@@ -128,7 +130,7 @@ SECTIONS {
 
     .iwram : AT(__iwram_lma) {
         KEEP(*(SORT(.iwram.sorted.*)))
-        *(.iwram)
+        *(.iwram .iwram.*)
         *.iwram.*(.data .data.* .text .text.*)
         *(.data .data.* .gnu.linkonce.d.*)
         . = ALIGN(32);


### PR DESCRIPTION
Fixes overlays. I've been using these changes locally without issue for some time now.

Issue was addressed in devkitARM in this PR: https://github.com/devkitPro/devkitarm-crtls/pull/4/files